### PR TITLE
Remove 5.2.3 from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog index
 
-[5.2.3](changelog-versions/5.2.3.md)
-
 [5.2.2](changelog-versions/5.2.2.md)
 
 [5.2.1](changelog-versions/5.2.1.md)

--- a/changelog-versions/5.2.3.md
+++ b/changelog-versions/5.2.3.md
@@ -1,4 +1,0 @@
-## 🐞 Bugs fixed
-
-- Available space for title in navbar [#658](https://github.com/Telefonica/mistica-design/issues/658)
-- Icons wrong sizing and unlinked instances in navigation bars [#660](https://github.com/Telefonica/mistica-design/issues/660)


### PR DESCRIPTION
The wrong milestone name was pushed to changelog, this PR removes the README file for the version, and the changelog entry
