### PR TITLE
Add movistar-classic to schema validator

### DIFF
--- a/.github/workflows/schema-validator.yml
+++ b/.github/workflows/schema-validator.yml
@@ -16,6 +16,16 @@ jobs:
           file: "tokens/movistar.json"
           schema: "tokens/schema/skin-schema.json"
 
+  Movistar-classic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate action.yml against a remote schema
+        uses: cardinalby/schema-validator-action@v1
+        with:
+          file: "tokens/movistar-classic.json"
+          schema: "tokens/schema/skin-schema.json"
+
   O2:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### 🎟 Jira Ticket
<!-- _Add design Jira Ticket here if exist_ -->

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### Release Notes
- New Feature: Added a new job to the schema validator workflow, `Movistar-classic`, which validates a JSON file against a remote schema.

> "A new job has arrived, 
> `Movistar-classic` is its name. 
> JSON files it will validate, 
> And make our workflow more tame."
<!-- end of auto-generated comment: release notes by openai -->