### PR TITLE
borderRadius before visual changes

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -1091,7 +1091,7 @@
       "type": "borderRadius"
     },
     "container": {
-      "value": "16",
+      "value": "8",
       "type": "borderRadius"
     },
     "indicator": {
@@ -1111,7 +1111,7 @@
       "type": "borderRadius"
     },
     "sheet": {
-      "value": "16",
+      "value": "8",
       "type": "borderRadius"
     }
   },

--- a/tokens/movistar-classic.json
+++ b/tokens/movistar-classic.json
@@ -1548,7 +1548,7 @@
       "type": "borderRadius"
     },
     "container": {
-      "value": "16",
+      "value": "8",
       "type": "borderRadius"
     },
     "indicator": {
@@ -1568,7 +1568,7 @@
       "type": "borderRadius"
     },
     "sheet": {
-      "value": "16",
+      "value": "8",
       "type": "borderRadius"
     }
   },

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -1091,7 +1091,7 @@
       "type": "borderRadius"
     },
     "container": {
-      "value": "16",
+      "value": "8",
       "type": "borderRadius"
     },
     "indicator": {
@@ -1111,7 +1111,7 @@
       "type": "borderRadius"
     },
     "sheet": {
-      "value": "16",
+      "value": "8",
       "type": "borderRadius"
     }
   },

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -1091,7 +1091,7 @@
       "type": "borderRadius"
     },
     "container": {
-      "value": "16",
+      "value": "8",
       "type": "borderRadius"
     },
     "indicator": {
@@ -1111,7 +1111,7 @@
       "type": "borderRadius"
     },
     "sheet": {
-      "value": "16",
+      "value": "8",
       "type": "borderRadius"
     }
   },

--- a/tokens/solar-360.json
+++ b/tokens/solar-360.json
@@ -1215,7 +1215,7 @@
       "type": "borderRadius"
     },
     "container": {
-      "value": "16",
+      "value": "8",
       "type": "borderRadius"
     },
     "indicator": {
@@ -1235,7 +1235,7 @@
       "type": "borderRadius"
     },
     "sheet": {
-      "value": "16",
+      "value": "8",
       "type": "borderRadius"
     }
   },


### PR DESCRIPTION
Updates the borderRadius values for several tokens in different JSON files. The new values are set to 8 instead of 16.
The motivation behind this change is to improve the consistency of borderRadius values across the project, as well as to ensure that the new values are applied before any visual changes are made.
This change will help to prevent any inconsistencies or errors that may occur due to the incorrect borderRadius values.
Overall, this change will improve the quality and consistency of the project.