### PR TITLE
Include branch information in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 There are exists 2 important branches in this repo:
 
 - `production`: This branch contains the currently live and stable version of the software or application that is being used by Android, iOS & Web platforms.
-- `pre-production`: This branch is a temporary working branch used to test and make final adjustments in tokens values before integrating into production.
+- `pre-production`: This branch is a temporary working branch used to test and make adjustments in features or tokens values. When they are finished, they are merged into production branch.
 
 # Figma
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 &nbsp;
 
-| Other Mística Repos                                              | Description                                               |
-| :--------------------------------------------------------------- | :-------------------------------------------------------- |
-| [mistica-web](https://github.com/Telefonica/mistica-web)         | Repository with code libraries for Mística in web         |
-| [mistica-ios](https://github.com/Telefonica/mistica-ios)         | Repository with code libraries for Mística in iOS         |
-| [mistica-android](https://github.com/Telefonica/mistica-android) | Repository with code libraries for Mística in Android     |
-| [mistica-icons](https://github.com/Telefonica/mistica-icons)     | The source of truth for icons in our digital products     |
+| Other Mística Repos                                              | Description                                           |
+| :--------------------------------------------------------------- | :---------------------------------------------------- |
+| [mistica-web](https://github.com/Telefonica/mistica-web)         | Repository with code libraries for Mística in web     |
+| [mistica-ios](https://github.com/Telefonica/mistica-ios)         | Repository with code libraries for Mística in iOS     |
+| [mistica-android](https://github.com/Telefonica/mistica-android) | Repository with code libraries for Mística in Android |
+| [mistica-icons](https://github.com/Telefonica/mistica-icons)     | The source of truth for icons in our digital products |
 
 ---
 
@@ -28,6 +28,13 @@
 ---
 
 <br/>
+
+# Branch organization
+
+There are exists 2 important branches in this repo:
+
+- `production`: This branch contains the currently live and stable version of the software or application that is being used by Android, iOS & Web platforms.
+- `pre-production`: This branch is a temporary working branch used to test and make final adjustments in tokens values before integrating into production.
 
 # Figma
 


### PR DESCRIPTION
Adds important information to the README.md file by including details about the branch organization in this repository.
Specifically, we have added a new section to the README that explains the two branches that exist in this repository - `production` and `pre-production`. This information is essential for anyone who wants to contribute to this repository, as it ensures that they understand the structure of the repository and how it is organized.

Overall, this change will improve the clarity and transparency of the project by providing contributors with essential information about the repository's branch organization.