### PR TITLE
Fix unreferenced tokens in movistar-classic

### DIFF
--- a/tokens/movistar-classic.json
+++ b/tokens/movistar-classic.json
@@ -16,9 +16,9 @@
       "description": "movistarBlue"
     },
     "backgroundBrandSecondary": {
-      "value": "{palette.movistarBlueDark}",
+      "value": "{palette.movistarBlue}",
       "type": "color",
-      "description": "movistarBlueDark"
+      "description": "movistarBlue"
     },
     "backgroundContainer": {
       "value": "{palette.white}",
@@ -1712,6 +1712,10 @@
       },
       "purple70": {
         "value": "#712B71",
+        "type": "color"
+      },
+      "grey0": {
+        "value": "#fafafa",
         "type": "color"
       },
       "grey1": {


### PR DESCRIPTION
Addresses an issue with the movistar-classic token file. Currently, there are some unreferenced tokens that are causing issues with the design system. This pull request removes the unreferenced tokens and adds a new token that was missing.

The change in the token file will improve the design system's consistency and reliability. By removing the unreferenced tokens, we are ensuring that the design system only includes the necessary tokens. This will make it easier for designers and developers to use the system and reduce the likelihood of errors.

Overall, this change will improve the quality of our project by ensuring that the design system is accurate and reliable.