### PR TITLE
Fix backgroundSkeleton and backgroundSkeletonInverse in darkMode

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -623,14 +623,14 @@
       "description": "darkModeGrey"
     },
     "backgroundSkeleton": {
-      "value": "{palette.darkModeGrey}",
+      "value": "{palette.darkModeGrey6}",
       "type": "color",
-      "description": "darkModeGrey"
+      "description": "darkModeGrey6"
     },
     "backgroundSkeletonInverse": {
-      "value": "{palette.darkModeGrey}",
+      "value": "{palette.darkModeGrey6}",
       "type": "color",
-      "description": "darkModeGrey"
+      "description": "darkModeGrey6"
     },
     "backgroundFeedbackBottom": {
       "value": "{palette.darkModeBlack}",

--- a/tokens/solar-360.json
+++ b/tokens/solar-360.json
@@ -685,14 +685,14 @@
       "description": "darkModeGrey"
     },
     "backgroundSkeleton": {
-      "value": "{palette.grey6}",
+      "value": "{palette.darkModeGrey6}",
       "type": "color",
-      "description": "grey6"
+      "description": "darkModeGrey6"
     },
     "backgroundSkeletonInverse": {
-      "value": "{palette.grey6}",
+      "value": "{palette.darkModeGrey6}",
       "type": "color",
-      "description": "grey6"
+      "description": "darkModeGrey6"
     },
     "backgroundFeedbackBottom": {
       "value": "{palette.darkModeBlack}",
@@ -1419,6 +1419,10 @@
       },
       "darkModeGrey": {
         "value": "#142027",
+        "type": "color"
+      },
+      "darkModeGrey6": {
+        "value": "#1C2C36",
         "type": "color"
       },
       "darkModeGrey7": {

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -623,14 +623,14 @@
       "description": "darkModeGrey"
     },
     "backgroundSkeleton": {
-      "value": "{palette.grey6}",
+      "value": "{palette.darkModeGrey6}",
       "type": "color",
-      "description": "grey6"
+      "description": "darkModeGrey6"
     },
     "backgroundSkeletonInverse": {
-      "value": "{palette.grey6}",
+      "value": "{palette.darkModeGrey6}",
       "type": "color",
-      "description": "grey6"
+      "description": "darkModeGrey6"
     },
     "backgroundFeedbackBottom": {
       "value": "{palette.darkModeBlack}",


### PR DESCRIPTION
Fixes an issue with the backgroundSkeleton and backgroundSkeletonInverse tokens in darkMode. These tokens were using the wrong color value, resulting in an incorrect color being displayed in dark mode.

The fix involves updating the color value for backgroundSkeleton and backgroundSkeletonInverse to use the correct color value for darkMode, which is now darkModeGrey6 instead of grey6.

This change helps to improve the consistency and accuracy of the color scheme in darkMode, which is an important aspect of the overall design of the project.