### PR TITLE
Fix movistar classic tokens

### DIFF
--- a/tokens/movistar-classic.json
+++ b/tokens/movistar-classic.json
@@ -16,9 +16,9 @@
       "description": "movistarBlue"
     },
     "backgroundBrandSecondary": {
-      "value": "{palette.movistarBlueDark}",
+      "value": "{palette.movistarBlue}",
       "type": "color",
-      "description": "movistarBlueDark"
+      "description": "movistarBlue"
     },
     "backgroundContainer": {
       "value": "{palette.white}",
@@ -1712,6 +1712,10 @@
       },
       "purple70": {
         "value": "#712B71",
+        "type": "color"
+      },
+      "grey0": {
+        "value": "#fafafa",
         "type": "color"
       },
       "grey1": {


### PR DESCRIPTION
Addresses an issue where the movistar classic tokens were not displaying the correct colors. Specifically, a typo in the color value for "backgroundBrandSecondary" was causing the wrong color to be displayed. 

To fix this issue, we have corrected the color value to match the correct movistar blue color. Additionally, we have added a new color value for "grey0", which was missing from the original file.

Overall, this change will improve the accuracy of our design system by ensuring that the correct colors are displayed for movistar classic tokens.