### PR TITLE
Change preset tokens to text + camelCase

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -1121,27 +1121,27 @@
         "value": "light",
         "type": "typography"
       },
-      "preset-5": {
+      "text5": {
         "value": "light",
         "type": "typography"
       },
-      "preset-6": {
+      "text6": {
         "value": "light",
         "type": "typography"
       },
-      "preset-7": {
+      "text7": {
         "value": "light",
         "type": "typography"
       },
-      "preset-8": {
+      "text8": {
         "value": "light",
         "type": "typography"
       },
-      "preset-9": {
+      "text9": {
         "value": "light",
         "type": "typography"
       },
-      "preset-10": {
+      "text10": {
         "value": "light",
         "type": "typography"
       }

--- a/tokens/movistar-legacy.json
+++ b/tokens/movistar-legacy.json
@@ -1578,27 +1578,27 @@
         "value": "bold",
         "type": "typography"
       },
-      "preset-5": {
+      "text5": {
         "value": "bold",
         "type": "typography"
       },
-      "preset-6": {
+      "text6": {
         "value": "bold",
         "type": "typography"
       },
-      "preset-7": {
+      "text7": {
         "value": "bold",
         "type": "typography"
       },
-      "preset-8": {
+      "text8": {
         "value": "bold",
         "type": "typography"
       },
-      "preset-9": {
+      "text9": {
         "value": "bold",
         "type": "typography"
       },
-      "preset-10": {
+      "text10": {
         "value": "bold",
         "type": "typography"
       }

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -1121,27 +1121,27 @@
         "value": "bold",
         "type": "typography"
       },
-      "preset-5": {
+      "text5": {
         "value": "bold",
         "type": "typography"
       },
-      "preset-6": {
+      "text6": {
         "value": "bold",
         "type": "typography"
       },
-      "preset-7": {
+      "text7": {
         "value": "bold",
         "type": "typography"
       },
-      "preset-8": {
+      "text8": {
         "value": "bold",
         "type": "typography"
       },
-      "preset-9": {
+      "text9": {
         "value": "bold",
         "type": "typography"
       },
-      "preset-10": {
+      "text10": {
         "value": "bold",
         "type": "typography"
       }

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -1121,27 +1121,27 @@
         "value": "light",
         "type": "typography"
       },
-      "preset-5": {
+      "text5": {
         "value": "light",
         "type": "typography"
       },
-      "preset-6": {
+      "text6": {
         "value": "light",
         "type": "typography"
       },
-      "preset-7": {
+      "text7": {
         "value": "light",
         "type": "typography"
       },
-      "preset-8": {
+      "text8": {
         "value": "light",
         "type": "typography"
       },
-      "preset-9": {
+      "text9": {
         "value": "light",
         "type": "typography"
       },
-      "preset-10": {
+      "text10": {
         "value": "light",
         "type": "typography"
       }

--- a/tokens/schema/skin-schema.json
+++ b/tokens/schema/skin-schema.json
@@ -294,12 +294,12 @@
       "additionalProperties": false,
       "properties": {
         "cardTitle": { "$ref": "#/definitions/weightProperties" },
-        "preset-5": { "$ref": "#/definitions/weightProperties" },
-        "preset-6": { "$ref": "#/definitions/weightProperties" },
-        "preset-7": { "$ref": "#/definitions/weightProperties" },
-        "preset-8": { "$ref": "#/definitions/weightProperties" },
-        "preset-9": { "$ref": "#/definitions/weightProperties" },
-        "preset-10": { "$ref": "#/definitions/weightProperties" }
+        "text5": { "$ref": "#/definitions/weightProperties" },
+        "text6": { "$ref": "#/definitions/weightProperties" },
+        "text7": { "$ref": "#/definitions/weightProperties" },
+        "text8": { "$ref": "#/definitions/weightProperties" },
+        "text9": { "$ref": "#/definitions/weightProperties" },
+        "text10": { "$ref": "#/definitions/weightProperties" }
       }
     }
   },

--- a/tokens/solar-360.json
+++ b/tokens/solar-360.json
@@ -1245,27 +1245,27 @@
         "value": "light",
         "type": "typography"
       },
-      "preset-5": {
+      "text5": {
         "value": "light",
         "type": "typography"
       },
-      "preset-6": {
+      "text6": {
         "value": "light",
         "type": "typography"
       },
-      "preset-7": {
+      "text7": {
         "value": "light",
         "type": "typography"
       },
-      "preset-8": {
+      "text8": {
         "value": "light",
         "type": "typography"
       },
-      "preset-9": {
+      "text9": {
         "value": "light",
         "type": "typography"
       },
-      "preset-10": {
+      "text10": {
         "value": "light",
         "type": "typography"
       }

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -1121,27 +1121,27 @@
         "value": "regular",
         "type": "typography"
       },
-      "preset-5": {
+      "text5": {
         "value": "regular",
         "type": "typography"
       },
-      "preset-6": {
+      "text6": {
         "value": "regular",
         "type": "typography"
       },
-      "preset-7": {
+      "text7": {
         "value": "regular",
         "type": "typography"
       },
-      "preset-8": {
+      "text8": {
         "value": "regular",
         "type": "typography"
       },
-      "preset-9": {
+      "text9": {
         "value": "regular",
         "type": "typography"
       },
-      "preset-10": {
+      "text10": {
         "value": "regular",
         "type": "typography"
       }

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -1121,27 +1121,27 @@
         "value": "regular",
         "type": "typography"
       },
-      "preset-5": {
+      "text5": {
         "value": "regular",
         "type": "typography"
       },
-      "preset-6": {
+      "text6": {
         "value": "regular",
         "type": "typography"
       },
-      "preset-7": {
+      "text7": {
         "value": "regular",
         "type": "typography"
       },
-      "preset-8": {
+      "text8": {
         "value": "regular",
         "type": "typography"
       },
-      "preset-9": {
+      "text9": {
         "value": "regular",
         "type": "typography"
       },
-      "preset-10": {
+      "text10": {
         "value": "regular",
         "type": "typography"
       }

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -1121,27 +1121,27 @@
         "value": "light",
         "type": "typography"
       },
-      "preset-5": {
+      "text5": {
         "value": "light",
         "type": "typography"
       },
-      "preset-6": {
+      "text6": {
         "value": "light",
         "type": "typography"
       },
-      "preset-7": {
+      "text7": {
         "value": "light",
         "type": "typography"
       },
-      "preset-8": {
+      "text8": {
         "value": "light",
         "type": "typography"
       },
-      "preset-9": {
+      "text9": {
         "value": "light",
         "type": "typography"
       },
-      "preset-10": {
+      "text10": {
         "value": "light",
         "type": "typography"
       }


### PR DESCRIPTION
Changes the preset token naming convention in several JSON files to text + camelCase. The current naming convention uses the format "preset-X" where X is a number. The new naming convention will use the format "textX".
 
The new naming convention will make it easier to understand and reference the token values. Using text + camelCase will help to make the token names more descriptive and easier to remember. 

This change will improve the readability and usability of the project, making it more user-friendly for developers and designers alike.