### PR TITLE
Adding applyAlpha to playroom guide

### DIFF
--- a/guides/playroom.md
+++ b/guides/playroom.md
@@ -316,6 +316,16 @@ colors.nombreDelColor
 
 [Ver ejemplo en playroom →](https://rebrand.ly/enphrfu)
 
+#### Opacity in colors
+
+Puedes aplicar opacidad a constantes de Mística
+
+```
+applyAlpha(skinVars.rawColors.inverse, 0.2)
+```
+
+[Ver ejemplo en playroom →](https://tinyurl.com/2luzuq49)
+
 ## Theme variant
 
 ![theme_inverse](https://user-images.githubusercontent.com/44420072/210542968-6460d343-febc-4866-adf4-53bc5ab6eceb.gif)


### PR DESCRIPTION
The purpose of this pull request is to add the `applyAlpha` function to the Playroom guide. The `applyAlpha` function is a useful tool for applying opacity to Mística color constants. This change will make it easier for developers to apply opacity to their designs, which is a common requirement in modern web development.

In addition, this pull request includes a link to a Playroom example that demonstrates the use of `applyAlpha`, making it easier for developers to understand and use this function.

Overall, this change will improve the usability of our Playroom guide and make it easier for developers to create designs with Mística colors.