### PR TITLE
Fix backgroundAlternative in dark mode in vivo-new 

### DIFF
--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -533,7 +533,7 @@
       "description": "darkModeBlack"
     },
     "backgroundAlternative": {
-      "value": "{palette.darkModeGrey}",
+      "value": "{palette.darkModeBlack}",
       "type": "color",
       "description": "darkModeGrey"
     },


### PR DESCRIPTION
Fixes a problem with the backgroundAlternative color value in dark mode in the vivo-new token. Currently, the value is set to darkModeGrey, which is incorrect and leads to inconsistencies in the design when used in dark mode.

This pull request updates the color value to darkModeBlack, which is the correct value for the backgroundAlternative color in dark mode. This change will ensure that the design in dark mode is consistent and visually pleasing.

Overall, this change will improve the user experience of the project by ensuring that the design is consistent and visually pleasing, even in dark mode.