### PR TITLE
Fix neutral low in blau

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -371,9 +371,9 @@
       "description": "grey5"
     },
     "neutralLow": {
-      "value": "{palette.grey2}",
+      "value": "{palette.grey1}",
       "type": "color",
-      "description": "grey2"
+      "description": "grey1"
     },
     "neutralLowAlternative": {
       "value": "{palette.grey2}",


### PR DESCRIPTION
Fixes an issue with the "neutralLow" value in the "blau" token. The value was previously set to "palette.grey2", but this caused the color to be darker than intended. The correct value is "palette.grey1", which produces the intended color.

This change is important because it ensures that the "blau" token behaves as expected, producing the correct color. This will improve the appearance and consistency of our project, ensuring that all users see the intended color for this token.

Overall, this change improves the quality of the project by fixing a visual issue and ensuring that the "blau" token behaves as intended.