### PR TITLE
Add size and line-height tokens

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -1141,6 +1141,24 @@
         "value": "light",
         "type": "typography"
       }
+    },
+    "size": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      }
+    },
+    "lineHeight": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      }
     }
   },
   "global": {

--- a/tokens/movistar-legacy.json
+++ b/tokens/movistar-legacy.json
@@ -1598,6 +1598,24 @@
         "value": "bold",
         "type": "typography"
       }
+    },
+    "size": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      }
+    },
+    "lineHeight": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      }
     }
   },
   "global": {

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -1142,6 +1142,24 @@
         "value": "bold",
         "type": "typography"
       }
+    },
+    "size": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      }
+    },
+    "lineHeight": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      }
     }
   },
   "global": {

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -1141,6 +1141,24 @@
         "value": "light",
         "type": "typography"
       }
+    },
+    "size": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      }
+    },
+    "lineHeight": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      }
     }
   },
   "global": {

--- a/tokens/schema/skin-schema.json
+++ b/tokens/schema/skin-schema.json
@@ -29,6 +29,12 @@
       "properties": {
         "weight": {
           "allOf": [{ "$ref": "#/global/weight" }]
+        },
+        "size": {
+          "allOf": [{ "$ref": "#/global/size" }]
+        },
+        "lineHeight": {
+          "allOf": [{ "$ref": "#/global/lineHeight" }]
         }
       }
     }
@@ -301,6 +307,18 @@
         "text9": { "$ref": "#/definitions/weightProperties" },
         "text10": { "$ref": "#/definitions/weightProperties" }
       }
+    },
+    "size": {
+      "additionalProperties": false,
+      "properties": {
+        "tabsLabel": { "$ref": "#/definitions/sizeProperties" }
+      }
+    },
+    "lineHeight": {
+      "additionalProperties": false,
+      "properties": {
+        "tabsLabel": { "$ref": "#/definitions/lineHeightProperties" }
+      }
     }
   },
   "definitions": {
@@ -352,6 +370,52 @@
         "value": {
           "type": "string",
           "pattern": "^(light|regular|medium|bold)+$"
+        },
+        "type": {
+          "const": "typography"
+        }
+      },
+      "required": ["value", "type"]
+    },
+    "sizeProperties": {
+      "type": "object",
+      "patternProperties": {
+        "value": {
+          "type": "object",
+          "properties": {
+            "desktop": {
+              "type": "number",
+              "enum": [16, 18]
+            },
+            "mobile": {
+              "type": "number",
+              "enum": [16, 18, 20, 24]
+            }
+          },
+          "required": ["desktop", "mobile"]
+        },
+        "type": {
+          "const": "typography"
+        }
+      },
+      "required": ["value", "type"]
+    },
+    "lineHeightProperties": {
+      "type": "object",
+      "patternProperties": {
+        "value": {
+          "type": "object",
+          "properties": {
+            "desktop": {
+              "type": "number",
+              "enum": [24]
+            },
+            "mobile": {
+              "type": "number",
+              "enum": [24]
+            }
+          },
+          "required": ["desktop", "mobile"]
         },
         "type": {
           "const": "typography"

--- a/tokens/solar-360.json
+++ b/tokens/solar-360.json
@@ -1265,6 +1265,24 @@
         "value": "light",
         "type": "typography"
       }
+    },
+    "size": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      }
+    },
+    "lineHeight": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      }
     }
   },
   "global": {

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -1141,6 +1141,24 @@
         "value": "regular",
         "type": "typography"
       }
+    },
+    "size": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      }
+    },
+    "lineHeight": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      }
     }
   },
   "global": {

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -1141,6 +1141,24 @@
         "value": "regular",
         "type": "typography"
       }
+    },
+    "size": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 18,
+          "desktop": 18
+        },
+        "type": "typography"
+      }
+    },
+    "lineHeight": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      }
     }
   },
   "global": {

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -1141,6 +1141,24 @@
         "value": "light",
         "type": "typography"
       }
+    },
+    "size": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      }
+    },
+    "lineHeight": {
+      "tabsLabel": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      }
     }
   },
   "global": {


### PR DESCRIPTION
Adds two new tokens to the existing token set: `size` and `lineHeight`. These tokens are added to the `tabsLabel` property of all the tokens files, and are used to define the font size and line height of the tab labels in the UI.

By adding these new tokens, we are able to provide more flexibility to our designers and developers when working with the UI. This change allows for more fine-grained control over the typography of the tabs label and overall better consistency in the design.

Overall, this change will improve the quality of the project by making it easier to maintain consistent typography throughout the UI.