### PR TITLE
Add tabsLabel fontWeight token

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -1105,6 +1105,10 @@
         "value": "medium",
         "type": "typography"
       },
+      "tabsLabel": {
+        "value": "medium",
+        "type": "typography"
+      },
       "link": {
         "value": "medium",
         "type": "typography"

--- a/tokens/movistar-legacy.json
+++ b/tokens/movistar-legacy.json
@@ -1562,6 +1562,10 @@
         "value": "medium",
         "type": "typography"
       },
+      "tabsLabel": {
+        "value": "medium",
+        "type": "typography"
+      },
       "link": {
         "value": "medium",
         "type": "typography"

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -1106,6 +1106,10 @@
         "value": "medium",
         "type": "typography"
       },
+      "tabsLabel": {
+        "value": "medium",
+        "type": "typography"
+      },
       "link": {
         "value": "medium",
         "type": "typography"

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -1105,6 +1105,10 @@
         "value": "medium",
         "type": "typography"
       },
+      "tabsLabel": {
+        "value": "medium",
+        "type": "typography"
+      },
       "link": {
         "value": "medium",
         "type": "typography"

--- a/tokens/schema/skin-schema.json
+++ b/tokens/schema/skin-schema.json
@@ -297,6 +297,7 @@
       "properties": {
         "cardTitle": { "$ref": "#/definitions/weightProperties" },
         "button": { "$ref": "#/definitions/weightProperties" },
+        "tabsLabel": { "$ref": "#/definitions/weightProperties" },
         "link": { "$ref": "#/definitions/weightProperties" },
         "indicator": { "$ref": "#/definitions/weightProperties" },
         "title1": { "$ref": "#/definitions/weightProperties" },

--- a/tokens/solar-360.json
+++ b/tokens/solar-360.json
@@ -1229,6 +1229,10 @@
         "value": "medium",
         "type": "typography"
       },
+      "tabsLabel": {
+        "value": "medium",
+        "type": "typography"
+      },
       "link": {
         "value": "medium",
         "type": "typography"

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -1105,6 +1105,10 @@
         "value": "medium",
         "type": "typography"
       },
+      "tabsLabel": {
+        "value": "medium",
+        "type": "typography"
+      },
       "link": {
         "value": "medium",
         "type": "typography"

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -1105,6 +1105,10 @@
         "value": "regular",
         "type": "typography"
       },
+      "tabsLabel": {
+        "value": "regular",
+        "type": "typography"
+      },
       "link": {
         "value": "regular",
         "type": "typography"

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -1105,6 +1105,10 @@
         "value": "medium",
         "type": "typography"
       },
+      "tabsLabel": {
+        "value": "medium",
+        "type": "typography"
+      },
       "link": {
         "value": "medium",
         "type": "typography"


### PR DESCRIPTION
Adds a new token to the project called "tabsLabel". This token defines the typography weight for labels used in tabs. By adding this token, we can now have a consistent and standardized typography weight for all tab labels across the project.

This change will improve the overall look and feel of the project by ensuring that all tab labels have a consistent typography weight. This will make the project more visually appealing and easier to use for users.

Overall, this change will improve the quality of the project by ensuring a consistent and standardized design for tab labels.