### PR TITLE
backgroundBrandSecondary to vivoPurpleLight90 in Vivo New

### DIFF
--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -16,9 +16,9 @@
       "description": "vivoPurple"
     },
     "backgroundBrandSecondary": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurpleLight90}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurpleLight90"
     },
     "backgroundContainer": {
       "value": "{palette.white}",


### PR DESCRIPTION
In this pull request, we are updating the background color of the "backgroundBrandSecondary" token in the Vivo New theme. The current value is set to "{palette.vivoPurple}", but we are changing it to "{palette.vivoPurpleLight90}".

This change improves the project by providing a lighter shade of the purple color for the secondary brand background. This can enhance the visual appeal and usability of the Vivo New theme, creating a more pleasing and cohesive user experience.

Overall, this update contributes to the overall design and aesthetics of the project, making it more visually appealing and consistent.