### PR TITLE
force uppercase in palette hex values

### DIFF
--- a/tokens/movistar-legacy.json
+++ b/tokens/movistar-legacy.json
@@ -1729,7 +1729,7 @@
         "type": "color"
       },
       "grey0": {
-        "value": "#fafafa",
+        "value": "#FAFAFA",
         "type": "color"
       },
       "grey1": {

--- a/tokens/schema/skin-schema.json
+++ b/tokens/schema/skin-schema.json
@@ -328,7 +328,7 @@
       "patternProperties": {
         "value": {
           "type": "string",
-          "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+          "pattern": "^#([A-F0-9]{6}|[A-F0-9]{3})$"
         },
         "type": {
           "const": "color"


### PR DESCRIPTION

This pull request enforces uppercase hex values in the palette of our project. Previously, the pattern allowed for both uppercase and lowercase letters, which could lead to inconsistencies and confusion.

By forcing uppercase hex values, we ensure a consistent and standardized format throughout the palette. This change improves the readability and maintainability of the codebase, making it easier for developers to work with the project.

Overall, this change enhances the project's consistency and clarity, contributing to a better user experience and smoother development process.