### PR TITLE
brandLow and sheet radius updated in Telefónica skin

### DIFF
--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -446,9 +446,9 @@
       "description": "orchid10"
     },
     "brandLow": {
-      "value": "{palette.grey1}",
+      "value": "{palette.telefonicaBlue10}",
       "type": "color",
-      "description": "grey1"
+      "description": "telefonicaBlue10"
     },
     "successHigh": {
       "value": "{palette.turquoise70}",
@@ -1091,7 +1091,7 @@
       "type": "borderRadius"
     },
     "sheet": {
-      "value": "8",
+      "value": "0",
       "type": "borderRadius"
     }
   },


### PR DESCRIPTION
The actual brandLow `grey1` happens to be `telefonicaBlue10`
With this change, we can fix the bug detected in issue #1357
Additionally, this PR includes updating the sheet border radius to "0" value