### PR TITLE
fix: Update background skeleton token in vivo-new

### DIFF
--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -71,9 +71,9 @@
       "description": "grey6"
     },
     "backgroundSkeleton": {
-      "value": "{palette.grey4}",
+      "value": "{palette.grey3}",
       "type": "color",
-      "description": "grey4"
+      "description": "grey3"
     },
     "backgroundSkeletonInverse": {
       "value": "{palette.vivoPurpleDark}",


### PR DESCRIPTION
https://mistica-design.vercel.app/tokens-map/aweell-background-skeleton.to-grey3-vivo-new/movistar/color/backgroundSkeleton/