### PR TITLE
Telefonica barTrack to grey2

### DIFF
--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -331,9 +331,9 @@
       "description": "coral"
     },
     "barTrack": {
-      "value": "{palette.grey3}",
+      "value": "{palette.grey2}",
       "type": "color",
-      "description": "grey3"
+      "description": "grey2"
     },
     "barTrackInverse": {
       "value": "rgba({palette.white}, 0.3)",


### PR DESCRIPTION
### Pull Request Description: Telefonica barTrack to grey2

This pull request updates the color reference for the `barTrack` property in the `telefonica.json` file from `grey3` to `grey2`. 

**Motivation:**
The change is motivated by the need for a more consistent and visually appealing color scheme within our application. The switch to `grey2` provides better contrast and aligns with our design guidelines, enhancing the overall user experience.

**Improvements:**
- **Visual Consistency**: Using `grey2` instead of `grey3` ensures that the UI elements maintain a cohesive look and feel.
- **Accessibility**: The updated color choice improves readability and accessibility, benefiting all users.
- **Design Alignment**: This change brings the color palette in line with our current branding and design objectives.

By implementing this change, we aim to improve the visual quality and accessibility of our application, ultimately leading to a better experience for our users.