### PR TITLE
fix(blau): Increase contrast in `control` token in Blau

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -306,9 +306,9 @@
       "description": "blauBluePrimary"
     },
     "control": {
-      "value": "{palette.grey2}",
+      "value": "{palette.grey5}",
       "type": "color",
-      "description": "grey2"
+      "description": "grey5"
     },
     "controlActivated": {
       "value": "{palette.blauBlueSecondary}",


### PR DESCRIPTION
Addresses the contrast of the `control` token in the Blau design system. By changing the value of the `control` token from `palette.grey2` to `palette.grey5`, we enhance the visibility and accessibility of UI elements that rely on this token.

The motivation behind this change is to improve user experience by ensuring that controls are more distinguishable against their backgrounds. Increased contrast is particularly important for users with visual impairments, making our application more inclusive and compliant with accessibility standards.

Overall, this update not only enhances the aesthetic quality of the UI but also contributes to better usability and accessibility across the project.

#1971