### PR TITLE
IOS-10974 fail when error

### DIFF
--- a/.github/workflows/sync-design-tokens.yml
+++ b/.github/workflows/sync-design-tokens.yml
@@ -17,17 +17,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
-      - name: Trigger mistica-web repo workflow
+      # - name: Trigger mistica-web repo workflow
+      #   run: |
+      #     curl -L -f \
+      #         -X POST \
+      #         -H "Authorization: Bearer ${{ secrets.NOVUM_PRIVATE_REPOS }}" \
+      #         -H "X-GitHub-Api-Version: 2022-11-28" \
+      #         -H "Accept: application/vnd.github+json" \
+      #         https://api.github.com/repos/telefonica/mistica-web/actions/workflows/import-design-tokens.yml/dispatches \
+      #         --data '{"ref": "master", "inputs": {"draft": ${{github.event.inputs.draft}}, "ref": "${{github.event.inputs.ref}}"}}'
+
+      - name: Testing a curl with success
         run: |
           curl -L -f \
-              -X POST \
-              -H "Authorization: Bearer ${{ secrets.NOVUM_PRIVATE_REPOS }}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              -H "Accept: application/vnd.github+json" \
-              https://api.github.com/repos/telefonica/mistica-web/actions/workflows/import-design-tokens.yml/dispatches \
-              --data '{"ref": "master", "inputs": {"draft": ${{github.event.inputs.draft}}, "ref": "${{github.event.inputs.ref}}"}}'
+              -X GET \
+              https://www.github.com
 
-      - name: Trigger mistica-ios repo workflow
+      - name: Testing a curl with failure
         run: |
           curl -L -f \
               -X POST \
@@ -37,12 +43,12 @@ jobs:
               https://api.github.com/repos/telefonica/mistica-ios/actions/workflows/generate-mistica-tokens.yml/dispatches \
               --data '{"ref": "main", "inputs": {"ref": "${{github.event.inputs.ref}}"}}'
 
-      - name: Trigger mistica-android repo workflow
-        run: |
-          curl -L -f \
-              -X POST \
-              -H "Authorization: Bearer ${{ secrets.NOVUM_PRIVATE_REPOS }}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              -H "Accept: application/vnd.github+json" \
-              https://api.github.com/repos/telefonica/mistica-android/actions/workflows/import-design-tokens.yml/dispatches \
-              --data '{"ref": "main", "inputs": {"ref": "${{github.event.inputs.ref}}"}}'
+      # - name: Trigger mistica-android repo workflow
+      #   run: |
+      #     curl -L -f \
+      #         -X POST \
+      #         -H "Authorization: Bearer ${{ secrets.NOVUM_PRIVATE_REPOS }}" \
+      #         -H "X-GitHub-Api-Version: 2022-11-28" \
+      #         -H "Accept: application/vnd.github+json" \
+      #         https://api.github.com/repos/telefonica/mistica-android/actions/workflows/import-design-tokens.yml/dispatches \
+      #         --data '{"ref": "main", "inputs": {"ref": "${{github.event.inputs.ref}}"}}'

--- a/.github/workflows/sync-design-tokens.yml
+++ b/.github/workflows/sync-design-tokens.yml
@@ -19,7 +19,7 @@ jobs:
       # https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
       - name: Trigger mistica-web repo workflow
         run: |
-          curl -L \
+          curl -L -f \
               -X POST \
               -H "Authorization: Bearer ${{ secrets.NOVUM_PRIVATE_REPOS }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -29,7 +29,7 @@ jobs:
 
       - name: Trigger mistica-ios repo workflow
         run: |
-          curl -L \
+          curl -L -f \
               -X POST \
               -H "Authorization: Bearer ${{ secrets.NOVUM_PRIVATE_REPOS }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -39,7 +39,7 @@ jobs:
 
       - name: Trigger mistica-android repo workflow
         run: |
-          curl -L \
+          curl -L -f \
               -X POST \
               -H "Authorization: Bearer ${{ secrets.NOVUM_PRIVATE_REPOS }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/.github/workflows/sync-design-tokens.yml
+++ b/.github/workflows/sync-design-tokens.yml
@@ -17,23 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
-      # - name: Trigger mistica-web repo workflow
-      #   run: |
-      #     curl -L -f \
-      #         -X POST \
-      #         -H "Authorization: Bearer ${{ secrets.NOVUM_PRIVATE_REPOS }}" \
-      #         -H "X-GitHub-Api-Version: 2022-11-28" \
-      #         -H "Accept: application/vnd.github+json" \
-      #         https://api.github.com/repos/telefonica/mistica-web/actions/workflows/import-design-tokens.yml/dispatches \
-      #         --data '{"ref": "master", "inputs": {"draft": ${{github.event.inputs.draft}}, "ref": "${{github.event.inputs.ref}}"}}'
-
-      - name: Testing a curl with success
+      - name: Trigger mistica-web repo workflow
         run: |
           curl -L -f \
-              -X GET \
-              https://www.github.com
+              -X POST \
+              -H "Authorization: Bearer ${{ secrets.NOVUM_PRIVATE_REPOS }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/telefonica/mistica-web/actions/workflows/import-design-tokens.yml/dispatches \
+              --data '{"ref": "master", "inputs": {"draft": ${{github.event.inputs.draft}}, "ref": "${{github.event.inputs.ref}}"}}'
 
-      - name: Testing a curl with failure
+      - name: Trigger mistica-ios repo workflow
         run: |
           curl -L -f \
               -X POST \
@@ -43,12 +37,12 @@ jobs:
               https://api.github.com/repos/telefonica/mistica-ios/actions/workflows/generate-mistica-tokens.yml/dispatches \
               --data '{"ref": "main", "inputs": {"ref": "${{github.event.inputs.ref}}"}}'
 
-      # - name: Trigger mistica-android repo workflow
-      #   run: |
-      #     curl -L -f \
-      #         -X POST \
-      #         -H "Authorization: Bearer ${{ secrets.NOVUM_PRIVATE_REPOS }}" \
-      #         -H "X-GitHub-Api-Version: 2022-11-28" \
-      #         -H "Accept: application/vnd.github+json" \
-      #         https://api.github.com/repos/telefonica/mistica-android/actions/workflows/import-design-tokens.yml/dispatches \
-      #         --data '{"ref": "main", "inputs": {"ref": "${{github.event.inputs.ref}}"}}'
+      - name: Trigger mistica-android repo workflow
+        run: |
+          curl -L -f \
+              -X POST \
+              -H "Authorization: Bearer ${{ secrets.NOVUM_PRIVATE_REPOS }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/telefonica/mistica-android/actions/workflows/import-design-tokens.yml/dispatches \
+              --data '{"ref": "main", "inputs": {"ref": "${{github.event.inputs.ref}}"}}'


### PR DESCRIPTION
Due to this action:
https://github.com/Telefonica/mistica-design/actions/runs/13055903096/job/36426747377#step:3:19

where the iOS curl fails, we want to be aware of.
Just adding `-f` to the `curl`, the job will fail in that step.

See: https://github.com/Telefonica/mistica-design/actions/runs/13072291576/job/36476394541
where I've simulated a success and failure curls:
https://github.com/Telefonica/mistica-design/pull/2049/commits/3341191dcfb21a3b8b09a35d96a21bde30a906d6

(The test has been reverted)
https://github.com/Telefonica/mistica-design/pull/2049/commits/d630d9c80891373a6f299fa349d66e15965f25d3