### PR TITLE
Fix tag info inverse tokens

### DIFF
--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -681,9 +681,9 @@
       "description": "grey5"
     },
     "tagTextInfoInverse": {
-      "value": "{palette.white}",
+      "value": "{palette.movistarBlueDark}",
       "type": "color",
-      "description": "white"
+      "description": "movistarBlueDark"
     },
     "tagTextSuccessInverse": {
       "value": "{palette.movistarGreen70}",
@@ -716,9 +716,9 @@
       "description": "white"
     },
     "tagBackgroundInfoInverse": {
-      "value": "{palette.movistarBlueDark}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "movistarBlueDark"
+      "description": "white"
     },
     "tagBackgroundSuccessInverse": {
       "value": "{palette.white}",


### PR DESCRIPTION
Addresses an inconsistency in the tag information for inverse tokens in the `movistar.json` file. 

### Changes Made:
- The `tagTextInfoInverse` color value has been updated from `{palette.white}` to `{palette.movistarBlueDark}`, ensuring that the text color for info tags is now correctly represented as the darker shade of Movistar blue.
- Conversely, the `tagBackgroundInfoInverse` color value has been changed from `{palette.movistarBlueDark}` to `{palette.white}`, aligning the background color with the expected design specifications for inverse tags.

### Motivation:
These changes are necessary to correct the visual design of the tags, ensuring that the colors used for text and backgrounds are appropriately matched. This will enhance the user interface by providing better contrast and readability, thereby improving the overall user experience.

By fixing these inverse token values, we ensure that the branding remains consistent and visually appealing, which is crucial for maintaining a professional appearance in our application.