### PR TITLE
feat(skin): Add inputBorder token

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -1069,9 +1069,9 @@
       "description": "blauBluePrimary"
     },
     "inputBorder": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.grey5}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "grey5"
     },
     "control": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -305,6 +305,11 @@
       "type": "color",
       "description": "blauBluePrimary"
     },
+    "inputBorder": {
+      "value": "{palette.grey5}",
+      "type": "color",
+      "description": "grey5"
+    },
     "control": {
       "value": "{palette.grey5}",
       "type": "color",
@@ -1062,6 +1067,11 @@
       "value": "{palette.blauBluePrimary}",
       "type": "color",
       "description": "blauBluePrimary"
+    },
+    "inputBorder": {
+      "value": "{palette.darkModeGrey6}",
+      "type": "color",
+      "description": "darkModeGrey6"
     },
     "control": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -337,6 +337,11 @@
       "type": "color",
       "description": "blue"
     },
+    "inputBorder": {
+      "value": "{palette.grey4}",
+      "type": "color",
+      "description": "grey4"
+    },
     "control": {
       "value": "{palette.grey4}",
       "type": "color",
@@ -1094,6 +1099,11 @@
       "value": "{palette.blue30}",
       "type": "color",
       "description": "blue30"
+    },
+    "inputBorder": {
+      "value": "{palette.grey4}",
+      "type": "color",
+      "description": "grey4"
     },
     "control": {
       "value": "{palette.grey4}",

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -1984,7 +1984,7 @@
         "type": "color"
       },
       "grey4": {
-        "value": "#9FA7B2",
+        "value": "#828D9B",
         "type": "color"
       },
       "grey5": {

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -1199,14 +1199,14 @@
       "description": "grey5"
     },
     "neutralLow": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.darkModeGrey7}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "darkModeGrey7"
     },
     "neutralLowAlternative": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.darkModeGrey7}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "darkModeGrey7"
     },
     "textPrimary": {
       "value": "{palette.darkModeGrey2}",
@@ -2024,7 +2024,7 @@
         "type": "color"
       },
       "darkModeGrey4": {
-        "value": "#85939C",
+        "value": "#89969F",
         "type": "color"
       },
       "darkModeGrey5": {

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -305,6 +305,11 @@
       "type": "color",
       "description": "movistarBlueHC"
     },
+    "inputBorder": {
+      "value": "{palette.grey4}",
+      "type": "color",
+      "description": "grey4"
+    },
     "control": {
       "value": "{palette.grey4}",
       "type": "color",
@@ -1062,6 +1067,11 @@
       "value": "{palette.movistarBlue}",
       "type": "color",
       "description": "movistarBlue"
+    },
+    "inputBorder": {
+      "value": "{palette.darkModeGrey4}",
+      "type": "color",
+      "description": "darkModeGrey4"
     },
     "control": {
       "value": "{palette.darkModeGrey4}",

--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -2000,7 +2000,7 @@
         "type": "color"
       },
       "grey45": {
-        "value": "#8C8C9A",
+        "value": "#8A8A98",
         "type": "color"
       },
       "grey60": {

--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -337,6 +337,11 @@
       "type": "color",
       "description": "beyondBlue"
     },
+    "inputBorder": {
+      "value": "{palette.grey45}",
+      "type": "color",
+      "description": "grey45"
+    },
     "control": {
       "value": "{palette.grey45}",
       "type": "color",
@@ -1094,6 +1099,11 @@
       "value": "{palette.beyondBlue30}",
       "type": "color",
       "description": "beyondBlue30"
+    },
+    "inputBorder": {
+      "value": "{palette.grey45}",
+      "type": "color",
+      "description": "grey45"
     },
     "control": {
       "value": "{palette.grey45}",

--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -1231,14 +1231,14 @@
       "description": "grey60"
     },
     "neutralLow": {
-      "value": "{palette.grey80}",
+      "value": "{palette.darkModeGrey6}",
       "type": "color",
-      "description": "grey80"
+      "description": "darkModeGrey6"
     },
     "neutralLowAlternative": {
-      "value": "{palette.grey80}",
+      "value": "{palette.darkModeGrey6}",
       "type": "color",
-      "description": "grey80"
+      "description": "darkModeGrey6"
     },
     "textPrimary": {
       "value": "{palette.grey30}",

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -305,6 +305,11 @@
       "type": "color",
       "description": "o2BluePrimary"
     },
+    "inputBorder": {
+      "value": "{palette.grey3}",
+      "type": "color",
+      "description": "grey3"
+    },
     "control": {
       "value": "{palette.grey3}",
       "type": "color",
@@ -1062,6 +1067,11 @@
       "value": "{palette.o2BluePrimary30}",
       "type": "color",
       "description": "o2BluePrimary30"
+    },
+    "inputBorder": {
+      "value": "{palette.darkModeGrey6}",
+      "type": "color",
+      "description": "darkModeGrey6"
     },
     "control": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/schema/skin-schema.json
+++ b/tokens/schema/skin-schema.json
@@ -203,7 +203,8 @@
         "tagBackgroundSuccessInverse",
         "tagBackgroundWarningInverse",
         "tagBackgroundErrorInverse",
-        "cardContentOverlay"
+        "cardContentOverlay",
+        "inputBorder"
       ],
       "properties": {
         "appBarBackground": { "$ref": "#/definitions/constantProperties" },
@@ -354,6 +355,7 @@
         "tagBackgroundWarningInverse": { "$ref": "#/definitions/constantProperties" },
         "tagBackgroundErrorInverse": { "$ref": "#/definitions/constantProperties" },
         "cardContentOverlay": { "$ref": "#/definitions/constantProperties" },
+        "inputBorder": { "$ref": "#/definitions/constantProperties" },
         "extended": {
           "type": "object",
           "patternProperties": {

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -456,9 +456,9 @@
       "description": "white"
     },
     "textSecondary": {
-      "value": "{palette.grey5}",
+      "value": "{palette.grey6}",
       "type": "color",
-      "description": "grey5"
+      "description": "grey6"
     },
     "textSecondaryInverse": {
       "value": "{palette.telefonicaBlue10}",

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -305,6 +305,11 @@
       "type": "color",
       "description": "telefonicaBlue"
     },
+    "inputBorder": {
+      "value": "{palette.grey3}",
+      "type": "color",
+      "description": "grey3"
+    },
     "control": {
       "value": "{palette.grey3}",
       "type": "color",
@@ -1062,6 +1067,11 @@
       "value": "{palette.telefonicaBlue}",
       "type": "color",
       "description": "telefonicaBlue"
+    },
+    "inputBorder": {
+      "value": "{palette.darkModeGrey6}",
+      "type": "color",
+      "description": "darkModeGrey6"
     },
     "control": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -1219,14 +1219,14 @@
       "description": "grey2"
     },
     "textSecondary": {
-      "value": "{palette.grey4}",
+      "value": "{palette.grey3}",
       "type": "color",
-      "description": "grey4"
+      "description": "grey3"
     },
     "textSecondaryInverse": {
-      "value": "{palette.grey4}",
+      "value": "{palette.grey3}",
       "type": "color",
-      "description": "grey4"
+      "description": "grey3"
     },
     "error": {
       "value": "{palette.coral}",

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -306,9 +306,9 @@
       "description": "telefonicaBlue"
     },
     "inputBorder": {
-      "value": "{palette.grey3}",
+      "value": "{palette.grey4}",
       "type": "color",
-      "description": "grey3"
+      "description": "grey4"
     },
     "control": {
       "value": "{palette.grey3}",
@@ -1069,9 +1069,9 @@
       "description": "telefonicaBlue"
     },
     "inputBorder": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.grey5}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "grey5"
     },
     "control": {
       "value": "{palette.darkModeGrey6}",
@@ -1920,7 +1920,7 @@
         "type": "color"
       },
       "grey4": {
-        "value": "#8F97AF",
+        "value": "#848CA4",
         "type": "color"
       },
       "grey5": {

--- a/tokens/tu.json
+++ b/tokens/tu.json
@@ -305,6 +305,11 @@
       "type": "color",
       "description": "blue"
     },
+    "inputBorder": {
+      "value": "{palette.grey5}",
+      "type": "color",
+      "description": "grey5"
+    },
     "control": {
       "value": "{palette.grey5}",
       "type": "color",
@@ -1062,6 +1067,11 @@
       "value": "{palette.blue30}",
       "type": "color",
       "description": "blue30"
+    },
+    "inputBorder": {
+      "value": "{palette.darkModeGrey6}",
+      "type": "color",
+      "description": "darkModeGrey6"
     },
     "control": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/tu.json
+++ b/tokens/tu.json
@@ -1069,9 +1069,9 @@
       "description": "blue30"
     },
     "inputBorder": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.grey5}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "grey5"
     },
     "control": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/tu.json
+++ b/tokens/tu.json
@@ -1219,14 +1219,14 @@
       "description": "grey2"
     },
     "textSecondary": {
-      "value": "{palette.grey4}",
+      "value": "{palette.grey3}",
       "type": "color",
-      "description": "grey4"
+      "description": "grey3"
     },
     "textSecondaryInverse": {
-      "value": "{palette.grey4}",
+      "value": "{palette.grey3}",
       "type": "color",
-      "description": "grey4"
+      "description": "grey3"
     },
     "error": {
       "value": "{palette.red}",

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -1932,7 +1932,7 @@
         "type": "color"
       },
       "grey4": {
-        "value": "#949494",
+        "value": "#8A8C90",
         "type": "color"
       },
       "grey5": {

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -305,6 +305,11 @@
       "type": "color",
       "description": "vivoPurple"
     },
+    "inputBorder": {
+      "value": "{palette.grey4}",
+      "type": "color",
+      "description": "grey4"
+    },
     "control": {
       "value": "{palette.grey4}",
       "type": "color",
@@ -1062,6 +1067,11 @@
       "value": "{palette.vivoPurpleLight80}",
       "type": "color",
       "description": "vivoPurpleLight80"
+    },
+    "inputBorder": {
+      "value": "{palette.darkModeGrey6}",
+      "type": "color",
+      "description": "darkModeGrey6"
     },
     "control": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -1219,14 +1219,14 @@
       "description": "grey2"
     },
     "textSecondary": {
-      "value": "{palette.grey4}",
+      "value": "{palette.grey3}",
       "type": "color",
-      "description": "grey4"
+      "description": "grey3"
     },
     "textSecondaryInverse": {
-      "value": "{palette.grey4}",
+      "value": "{palette.grey3}",
       "type": "color",
-      "description": "grey4"
+      "description": "grey3"
     },
     "success": {
       "value": "{palette.vivoGreen}",

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -1069,9 +1069,9 @@
       "description": "vivoPurpleLight80"
     },
     "inputBorder": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.darkModeGrey5}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "darkModeGrey5"
     },
     "control": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -305,6 +305,11 @@
       "type": "color",
       "description": "vivoPurple"
     },
+    "inputBorder": {
+      "value": "{palette.grey3}",
+      "type": "color",
+      "description": "grey3"
+    },
     "control": {
       "value": "{palette.grey3}",
       "type": "color",
@@ -1062,6 +1067,11 @@
       "value": "{palette.vivoPurpleLight80}",
       "type": "color",
       "description": "vivoPurpleLight80"
+    },
+    "inputBorder": {
+      "value": "{palette.darkModeGrey6}",
+      "type": "color",
+      "description": "darkModeGrey6"
     },
     "control": {
       "value": "{palette.darkModeGrey6}",


### PR DESCRIPTION
### Pull Request Description: Add inputBorder token

This pull request introduces a new `inputBorder` token across multiple token files, enhancing the design system by providing a consistent way to define input field borders.

#### Motivation
The addition of the `inputBorder` token serves to standardize the styling of input fields across different themes and platforms. By defining a dedicated token for input borders, we ensure that our UI components maintain visual consistency and adhere to design specifications, which is crucial for a seamless user experience.

#### Improvements
- **Consistency**: The `inputBorder` token promotes uniformity in input field styling, reducing discrepancies between different components and themes.
- **Maintainability**: Centralizing the definition of input borders simplifies future updates and modifications. Changes to the border style can now be made in one place, ensuring that all components are updated automatically.
- **Theming Support**: The token supports various palettes, allowing for easy customization based on the active theme (light or dark mode), improving accessibility and aesthetic appeal.

This enhancement not only streamlines our design process but also aligns with best practices for scalable UI development.