### PR TITLE
eSimFLAG: Update tagBackgroundPromo token

### DIFF
--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -668,9 +668,9 @@
       "description": "blue85"
     },
     "tagBackgroundPromo": {
-      "value": "{palette.blush20}",
+      "value": "{palette.blush}",
       "type": "color",
-      "description": "blush20"
+      "description": "blush"
     },
     "tagBackgroundActive": {
       "value": "{palette.teal}",


### PR DESCRIPTION
Updated token for `tagBackgroundPromo`: `blush20` is now `blush`.