### PR TITLE
Update tagBackgroundActive color on Vivo New token sheet

### DIFF
--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -636,7 +636,7 @@
       "description": "vivoPurple100"
     },
     "tagBackgroundActive": {
-      "value": "{palette.vivoPurple100}",
+      "value": "{palette.neutral100}",
       "type": "color",
       "description": "vivoPurple100"
     },

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -6,19 +6,19 @@
       "description": "white"
     },
     "backgroundAlternative": {
-      "value": "{palette.grey1}",
+      "value": "{palette.neutral100}",
       "type": "color",
-      "description": "grey1"
+      "description": "neutral100"
     },
     "backgroundBrand": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "backgroundBrandSecondary": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurpleLight80"
+      "description": "vivoPurple700"
     },
     "backgroundContainer": {
       "value": "{palette.white}",
@@ -26,69 +26,69 @@
       "description": "white"
     },
     "backgroundContainerError": {
-      "value": "{palette.pepperLight10}",
+      "value": "{palette.vivoPink100}",
       "type": "color",
-      "description": "pepperLight10"
+      "description": "vivoPink100"
     },
     "backgroundContainerHover": {
-      "value": "rgba({palette.darkModeBlack}, 0.05)",
+      "value": "rgba({palette.neutral900}, 0.05)",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "backgroundContainerPressed": {
-      "value": "rgba({palette.darkModeBlack}, 0.08)",
+      "value": "rgba({palette.neutral900}, 0.08)",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "backgroundContainerBrand": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "backgroundContainerBrandHover": {
-      "value": "rgba({palette.darkModeBlack}, 0.2)",
+      "value": "rgba({palette.neutral900}, 0.2)",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "backgroundContainerBrandPressed": {
-      "value": "rgba({palette.darkModeBlack}, 0.4)",
+      "value": "rgba({palette.neutral900}, 0.4)",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "backgroundContainerBrandOverInverse": {
-      "value": "{palette.vivoPurpleDark}",
+      "value": "{palette.vivoPurple900}",
       "type": "color",
-      "description": "vivoPurpleDark"
+      "description": "vivoPurple900"
     },
     "backgroundContainerAlternative": {
-      "value": "{palette.grey1}",
+      "value": "{palette.neutral100}",
       "type": "color",
-      "description": "grey1"
+      "description": "neutral100"
     },
     "backgroundOverlay": {
-      "value": "rgba({palette.grey6}, 0.6)",
+      "value": "rgba({palette.black}, 0.6)",
       "type": "color",
-      "description": "grey6"
+      "description": "black"
     },
     "backgroundSkeleton": {
-      "value": "{palette.grey3}",
+      "value": "{palette.neutral300}",
       "type": "color",
-      "description": "grey3"
+      "description": "neutral300"
     },
     "backgroundSkeletonInverse": {
-      "value": "{palette.vivoPurpleDark}",
+      "value": "{palette.vivoPurple900}",
       "type": "color",
-      "description": "vivoPurpleDark"
+      "description": "vivoPurple900"
     },
     "backgroundBrandTop": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "backgroundBrandBottom": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "appBarBackground": {
       "value": "{palette.white}",
@@ -96,64 +96,64 @@
       "description": "white"
     },
     "navigationBarBackground": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "skeletonWave": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "borderLow": {
-      "value": "{palette.grey1}",
+      "value": "{palette.neutral100}",
       "type": "color",
-      "description": "grey1"
+      "description": "neutral100"
     },
     "border": {
-      "value": "{palette.grey3}",
+      "value": "{palette.neutral300}",
       "type": "color",
-      "description": "grey3"
+      "description": "neutral300"
     },
     "borderHigh": {
-      "value": "{palette.grey5}",
+      "value": "{palette.neutral600}",
       "type": "color",
-      "description": "grey5"
+      "description": "neutral600"
     },
     "borderSelected": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "coverBackgroundHover": {
-      "value": "rgba({palette.darkModeBlack}, 0.25)",
+      "value": "rgba({palette.neutral900}, 0.25)",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "coverBackgroundPressed": {
-      "value": "rgba({palette.darkModeBlack}, 0.35)",
+      "value": "rgba({palette.neutral900}, 0.35)",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "buttonDangerBackground": {
-      "value": "{palette.pepper}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pepper"
+      "description": "vivoPink500"
     },
     "buttonDangerBackgroundPressed": {
-      "value": "{palette.pepperDark}",
+      "value": "{palette.vivoPink700}",
       "type": "color",
-      "description": "pepperDark"
+      "description": "vivoPink700"
     },
     "buttonDangerBackgroundHover": {
-      "value": "{palette.pepperDark}",
+      "value": "{palette.vivoPink700}",
       "type": "color",
-      "description": "pepperDark"
+      "description": "vivoPink700"
     },
     "buttonLinkDangerBackgroundPressed": {
-      "value": "{palette.pepperLight10}",
+      "value": "{palette.vivoPink100}",
       "type": "color",
-      "description": "pepperLight10"
+      "description": "vivoPink100"
     },
     "buttonLinkDangerBackgroundInverse": {
       "value": "{palette.white}",
@@ -161,14 +161,14 @@
       "description": "white"
     },
     "buttonLinkDangerBackgroundInversePressed": {
-      "value": "{palette.pepperLight10}",
+      "value": "{palette.vivoPink100}",
       "type": "color",
-      "description": "pepperLight10"
+      "description": "vivoPink100"
     },
     "buttonLinkBackgroundPressed": {
-      "value": "{palette.vivoPurpleLight10}",
+      "value": "{palette.vivoPurple100}",
       "type": "color",
-      "description": "vivoPurpleLight10"
+      "description": "vivoPurple100"
     },
     "buttonLinkBackgroundInversePressed": {
       "value": "rgba({palette.white}, 0.1)",
@@ -176,9 +176,9 @@
       "description": "white"
     },
     "buttonPrimaryBackground": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "buttonPrimaryBackgroundInverse": {
       "value": "{palette.white}",
@@ -186,39 +186,39 @@
       "description": "white"
     },
     "buttonPrimaryBackgroundPressed": {
-      "value": "{palette.vivoPurpleDark}",
+      "value": "{palette.vivoPurple900}",
       "type": "color",
-      "description": "vivoPurpleDark"
+      "description": "vivoPurple900"
     },
     "buttonPrimaryBackgroundHover": {
-      "value": "{palette.vivoPurpleDark}",
+      "value": "{palette.vivoPurple900}",
       "type": "color",
-      "description": "vivoPurpleDark"
+      "description": "vivoPurple900"
     },
     "buttonPrimaryBackgroundInversePressed": {
-      "value": "{palette.vivoPurpleLight50}",
+      "value": "{palette.vivoPurple400}",
       "type": "color",
-      "description": "vivoPurpleLight50"
+      "description": "vivoPurple400"
     },
     "buttonSecondaryBorder": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "buttonSecondaryBorderPressed": {
-      "value": "{palette.vivoPurpleDark}",
+      "value": "{palette.vivoPurple900}",
       "type": "color",
-      "description": "vivoPurpleDark"
+      "description": "vivoPurple900"
     },
     "buttonSecondaryBackgroundHover": {
-      "value": "{palette.vivoPurpleLight10}",
+      "value": "{palette.vivoPurple100}",
       "type": "color",
-      "description": "vivoPurpleLight10"
+      "description": "vivoPurple100"
     },
     "buttonSecondaryBackgroundPressed": {
-      "value": "{palette.vivoPurpleLight10}",
+      "value": "{palette.vivoPurple100}",
       "type": "color",
-      "description": "vivoPurpleLight10"
+      "description": "vivoPurple100"
     },
     "buttonSecondaryBorderInverse": {
       "value": "{palette.white}",
@@ -246,24 +246,24 @@
       "description": "white"
     },
     "textButtonPrimaryInverse": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "textButtonPrimaryInversePressed": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "textButtonSecondary": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "textButtonSecondaryPressed": {
-      "value": "{palette.vivoPurpleDark}",
+      "value": "{palette.vivoPurple900}",
       "type": "color",
-      "description": "vivoPurpleDark"
+      "description": "vivoPurple900"
     },
     "textButtonSecondaryInverse": {
       "value": "{palette.white}",
@@ -276,9 +276,9 @@
       "description": "white"
     },
     "textLink": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "textLinkInverse": {
       "value": "{palette.white}",
@@ -286,44 +286,39 @@
       "description": "white"
     },
     "textLinkDanger": {
-      "value": "{palette.pepper}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pepper"
+      "description": "vivoPink500"
     },
     "textLinkSnackbar": {
-      "value": "{palette.vivoPurpleLight20}",
+      "value": "{palette.vivoPurple200}",
       "type": "color",
-      "description": "vivoPurpleLight20"
+      "description": "vivoPurple200"
     },
     "textActivated": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "textBrand": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
-    },
-    "inputBorder": {
-      "value": "{palette.grey4}",
-      "type": "color",
-      "description": "grey4"
+      "description": "vivoPurple800"
     },
     "control": {
-      "value": "{palette.grey4}",
+      "value": "{palette.neutral500}",
       "type": "color",
-      "description": "grey4"
+      "description": "neutral500"
     },
     "controlActivated": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "controlInverse": {
-      "value": "{palette.vivoPurpleLight50}",
+      "value": "{palette.vivoPurple400}",
       "type": "color",
-      "description": "vivoPurpleLight50"
+      "description": "vivoPurple400"
     },
     "controlActivatedInverse": {
       "value": "{palette.white}",
@@ -331,14 +326,14 @@
       "description": "white"
     },
     "controlError": {
-      "value": "{palette.pepper}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pepper"
+      "description": "vivoPink500"
     },
     "barTrack": {
-      "value": "{palette.grey3}",
+      "value": "{palette.neutral300}",
       "type": "color",
-      "description": "grey3"
+      "description": "neutral300"
     },
     "barTrackInverse": {
       "value": "rgba({palette.white}, 0.5)",
@@ -346,24 +341,24 @@
       "description": "white"
     },
     "loadingBar": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "loadingBarBackground": {
-      "value": "{palette.vivoPurpleLight10}",
+      "value": "{palette.vivoPurple100}",
       "type": "color",
-      "description": "vivoPurpleLight10"
+      "description": "vivoPurple100"
     },
     "toggleAndroidInactive": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "toggleAndroidBackgroundActive": {
-      "value": "{palette.vivoPurpleLight20}",
+      "value": "{palette.vivoPurple200}",
       "type": "color",
-      "description": "vivoPurpleLight20"
+      "description": "vivoPurple200"
     },
     "iosControlKnob": {
       "value": "{palette.white}",
@@ -371,14 +366,14 @@
       "description": "white"
     },
     "controlKnobInverse": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "divider": {
-      "value": "{palette.grey3}",
+      "value": "{palette.neutral300}",
       "type": "color",
-      "description": "grey3"
+      "description": "neutral300"
     },
     "dividerInverse": {
       "value": "rgba({palette.white}, 0.2)",
@@ -386,34 +381,34 @@
       "description": "white"
     },
     "navigationBarDivider": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "badge": {
-      "value": "{palette.pepperDark}",
+      "value": "{palette.vivoPink700}",
       "type": "color",
-      "description": "pepperDark"
+      "description": "vivoPink700"
     },
     "feedbackErrorBackground": {
-      "value": "{palette.pepper}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pepper"
+      "description": "vivoPink500"
     },
     "feedbackInfoBackground": {
-      "value": "{palette.vivoPurpleDark}",
+      "value": "{palette.vivoPurple900}",
       "type": "color",
-      "description": "vivoPurpleDark"
+      "description": "vivoPurple900"
     },
     "brand": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "brandHigh": {
-      "value": "{palette.vivoPurpleDark}",
+      "value": "{palette.vivoPurple900}",
       "type": "color",
-      "description": "vivoPurpleDark"
+      "description": "vivoPurple900"
     },
     "inverse": {
       "value": "{palette.white}",
@@ -421,34 +416,34 @@
       "description": "white"
     },
     "neutralHigh": {
-      "value": "{palette.grey6}",
+      "value": "{palette.black}",
       "type": "color",
-      "description": "grey6"
+      "description": "black"
     },
     "neutralMedium": {
-      "value": "{palette.grey5}",
+      "value": "{palette.neutral600}",
       "type": "color",
-      "description": "grey5"
+      "description": "neutral600"
     },
     "neutralMediumInverse": {
-      "value": "{palette.grey5}",
+      "value": "{palette.neutral600}",
       "type": "color",
-      "description": "grey5"
+      "description": "neutral600"
     },
     "neutralLow": {
-      "value": "{palette.grey1}",
+      "value": "{palette.neutral100}",
       "type": "color",
-      "description": "grey1"
+      "description": "neutral100"
     },
     "neutralLowAlternative": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "textPrimary": {
-      "value": "{palette.grey6}",
+      "value": "{palette.black}",
       "type": "color",
-      "description": "grey6"
+      "description": "black"
     },
     "textPrimaryInverse": {
       "value": "{palette.white}",
@@ -456,114 +451,114 @@
       "description": "white"
     },
     "textSecondary": {
-      "value": "{palette.grey5}",
+      "value": "{palette.neutral600}",
       "type": "color",
-      "description": "grey5"
+      "description": "neutral600"
     },
     "textSecondaryInverse": {
-      "value": "{palette.vivoPurpleLight20}",
+      "value": "{palette.vivoPurple200}",
       "type": "color",
-      "description": "vivoPurpleLight20"
+      "description": "vivoPurple200"
     },
     "success": {
-      "value": "{palette.vivoGreen}",
+      "value": "{palette.vivoGreen500}",
       "type": "color",
-      "description": "vivoGreen"
+      "description": "vivoGreen500"
     },
     "warning": {
-      "value": "{palette.orange}",
+      "value": "{palette.vivoOrange500}",
       "type": "color",
-      "description": "orange"
+      "description": "vivoOrange500"
     },
     "error": {
-      "value": "{palette.pepper}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pepper"
+      "description": "vivoPink500"
     },
     "textError": {
-      "value": "{palette.pepper}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pepper"
+      "description": "vivoPink500"
     },
     "textErrorInverse": {
-      "value": "{palette.white}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "white"
+      "description": "vivoPink500"
     },
     "promo": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "highlight": {
-      "value": "{palette.pink}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pink"
+      "description": "vivoPink500"
     },
     "successLow": {
-      "value": "{palette.vivoGreenLight10}",
+      "value": "{palette.vivoGreen100}",
       "type": "color",
-      "description": "vivoGreenLight10"
+      "description": "vivoGreen100"
     },
     "warningLow": {
-      "value": "{palette.orangeLight10}",
+      "value": "{palette.vivoOrange100}",
       "type": "color",
-      "description": "orangeLight10"
+      "description": "vivoOrange100"
     },
     "errorLow": {
-      "value": "{palette.pepperLight10}",
+      "value": "{palette.vivoPink100}",
       "type": "color",
-      "description": "pepperLight10"
+      "description": "vivoPink100"
     },
     "promoLow": {
-      "value": "{palette.vivoPurpleLight10}",
+      "value": "{palette.vivoPurple100}",
       "type": "color",
-      "description": "vivoPurpleLight10"
+      "description": "vivoPurple100"
     },
     "brandLow": {
-      "value": "{palette.vivoPurpleLight10}",
+      "value": "{palette.vivoPurple100}",
       "type": "color",
-      "description": "vivoPurpleLight10"
+      "description": "vivoPurple100"
     },
     "successHigh": {
-      "value": "{palette.vivoGreenDark}",
+      "value": "{palette.vivoGreen900}",
       "type": "color",
-      "description": "vivoGreenDark"
+      "description": "vivoGreen900"
     },
     "warningHigh": {
-      "value": "{palette.orangeDark}",
+      "value": "{palette.vivoOrange800}",
       "type": "color",
-      "description": "orangeDark"
+      "description": "vivoOrange800"
     },
     "errorHigh": {
-      "value": "{palette.pepperDark80}",
+      "value": "{palette.vivoPink800}",
       "type": "color",
-      "description": "pepperDark80"
+      "description": "vivoPink800"
     },
     "promoHigh": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "successHighInverse": {
-      "value": "{palette.vivoGreenDark}",
+      "value": "{palette.vivoGreen900}",
       "type": "color",
-      "description": "vivoGreenDark"
+      "description": "vivoGreen900"
     },
     "warningHighInverse": {
-      "value": "{palette.orangeDark}",
+      "value": "{palette.vivoOrange800}",
       "type": "color",
-      "description": "orangeDark"
+      "description": "vivoOrange800"
     },
     "errorHighInverse": {
-      "value": "{palette.pepperDark80}",
+      "value": "{palette.vivoPink800}",
       "type": "color",
-      "description": "pepperDark80"
+      "description": "vivoPink800"
     },
     "promoHighInverse": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "textNavigationBarPrimary": {
       "value": "{palette.white}",
@@ -571,14 +566,14 @@
       "description": "white"
     },
     "textNavigationBarSecondary": {
-      "value": "{palette.vivoPurpleLight50}",
+      "value": "{palette.vivoPurple400}",
       "type": "color",
-      "description": "vivoPurpleLight50"
+      "description": "vivoPurple400"
     },
     "textNavigationSearchBarHint": {
-      "value": "{palette.vivoPurpleLight50}",
+      "value": "{palette.vivoPurple400}",
       "type": "color",
-      "description": "vivoPurpleLight50"
+      "description": "vivoPurple400"
     },
     "textNavigationSearchBarText": {
       "value": "{palette.white}",
@@ -586,14 +581,14 @@
       "description": "white"
     },
     "textAppBar": {
-      "value": "{palette.grey5}",
+      "value": "{palette.neutral600}",
       "type": "color",
-      "description": "grey5"
+      "description": "neutral600"
     },
     "textAppBarSelected": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "customTabsBackground": {
       "value": "{palette.white}",
@@ -601,144 +596,144 @@
       "description": "white"
     },
     "tagTextPromo": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "tagTextActive": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "tagTextInactive": {
-      "value": "{palette.grey5}",
+      "value": "{palette.neutral600}",
       "type": "color",
-      "description": "grey5"
+      "description": "neutral600"
     },
     "tagTextInfo": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "tagTextSuccess": {
-      "value": "{palette.vivoGreenDark}",
+      "value": "{palette.vivoGreen900}",
       "type": "color",
-      "description": "vivoGreenDark"
+      "description": "vivoGreen900"
     },
     "tagTextWarning": {
-      "value": "{palette.orangeDark}",
+      "value": "{palette.vivoOrange800}",
       "type": "color",
-      "description": "orangeDark"
+      "description": "vivoOrange800"
     },
     "tagTextError": {
-      "value": "{palette.pepperDark80}",
+      "value": "{palette.vivoPink800}",
       "type": "color",
-      "description": "pepperDark80"
+      "description": "vivoPink800"
     },
     "tagBackgroundPromo": {
-      "value": "{palette.vivoPurpleLight10}",
+      "value": "{palette.vivoPurple100}",
       "type": "color",
-      "description": "vivoPurpleLight10"
+      "description": "vivoPurple100"
     },
     "tagBackgroundActive": {
-      "value": "{palette.vivoPurpleLight10}",
+      "value": "{palette.vivoPurple100}",
       "type": "color",
-      "description": "vivoPurpleLight10"
+      "description": "vivoPurple100"
     },
     "tagBackgroundInactive": {
-      "value": "{palette.grey1}",
+      "value": "{palette.neutral100}",
       "type": "color",
-      "description": "grey1"
+      "description": "neutral100"
     },
     "tagBackgroundInfo": {
-      "value": "{palette.vivoPurpleLight10}",
+      "value": "{palette.vivoPurple100}",
       "type": "color",
-      "description": "vivoPurpleLight10"
+      "description": "vivoPurple100"
     },
     "tagBackgroundSuccess": {
-      "value": "{palette.vivoGreenLight10}",
+      "value": "{palette.vivoGreen100}",
       "type": "color",
-      "description": "vivoGreenLight10"
+      "description": "vivoGreen100"
     },
     "tagBackgroundWarning": {
-      "value": "{palette.orangeLight10}",
+      "value": "{palette.vivoOrange100}",
       "type": "color",
-      "description": "orangeLight10"
+      "description": "vivoOrange100"
     },
     "tagBackgroundError": {
-      "value": "{palette.pepperLight10}",
+      "value": "{palette.vivoPink100}",
       "type": "color",
-      "description": "pepperLight10"
+      "description": "vivoPink100"
     },
     "tagTextPromoInverse": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple400}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple400"
     },
     "tagTextActiveInverse": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple700"
     },
     "tagTextInactiveInverse": {
-      "value": "{palette.grey5}",
+      "value": "{palette.neutral600}",
       "type": "color",
-      "description": "grey5"
+      "description": "neutral600"
     },
     "tagTextInfoInverse": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple700"
     },
     "tagTextSuccessInverse": {
-      "value": "{palette.vivoGreenDark}",
+      "value": "{palette.vivoGreen400}",
       "type": "color",
-      "description": "vivoGreenDark"
+      "description": "vivoGreen400"
     },
     "tagTextWarningInverse": {
-      "value": "{palette.orangeDark}",
+      "value": "{palette.vivoOrange400}",
       "type": "color",
-      "description": "orangeDark"
+      "description": "vivoOrange400"
     },
     "tagTextErrorInverse": {
-      "value": "{palette.pepperDark80}",
+      "value": "{palette.vivoPink400}",
       "type": "color",
-      "description": "pepperDark80"
+      "description": "vivoPink400"
     },
     "tagBackgroundPromoInverse": {
-      "value": "{palette.vivoPurpleLight10}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "vivoPurpleLight10"
+      "description": "neutral700"
     },
     "tagBackgroundActiveInverse": {
-      "value": "{palette.vivoPurpleLight10}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "vivoPurpleLight10"
+      "description": "neutral700"
     },
     "tagBackgroundInactiveInverse": {
-      "value": "{palette.grey1}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "grey1"
+      "description": "neutral700"
     },
     "tagBackgroundInfoInverse": {
-      "value": "{palette.vivoPurpleLight10}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "vivoPurpleLight10"
+      "description": "neutral700"
     },
     "tagBackgroundSuccessInverse": {
-      "value": "{palette.vivoGreenLight10}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "vivoGreenLight10"
+      "description": "neutral700"
     },
     "tagBackgroundWarningInverse": {
-      "value": "{palette.orangeLight10}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "orangeLight10"
+      "description": "neutral700"
     },
     "tagBackgroundErrorInverse": {
-      "value": "{palette.pepperLight10}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "pepperLight10"
+      "description": "neutral700"
     },
     "cardContentOverlay": {
       "type": "linear-gradient",
@@ -746,52 +741,52 @@
         "angle": 180,
         "colors": [
           {
-            "value": "rgba({palette.grey6}, 0)",
+            "value": "rgba({palette.black}, 0)",
             "stop": 0
           },
           {
-            "value": "rgba({palette.grey6}, 0.4)",
+            "value": "rgba({palette.black}, 0.4)",
             "stop": 0.3
           },
           {
-            "value": "rgba({palette.grey6}, 0.7)",
+            "value": "rgba({palette.black}, 0.7)",
             "stop": 1
           }
         ]
       },
-      "description": "grey6"
+      "description": "black"
     }
   },
   "dark": {
     "background": {
-      "value": "{palette.darkModeBlack}",
+      "value": "{palette.neutral900}",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "backgroundAlternative": {
-      "value": "{palette.darkModeBlack}",
+      "value": "{palette.neutral900}",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "backgroundBrand": {
-      "value": "{palette.darkModeBlack}",
+      "value": "{palette.neutral900}",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "backgroundBrandSecondary": {
-      "value": "{palette.darkModeBlack}",
+      "value": "{palette.neutral900}",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "backgroundContainer": {
-      "value": "{palette.darkModeGrey}",
+      "value": "{palette.neutral800}",
       "type": "color",
-      "description": "darkModeGrey"
+      "description": "neutral800"
     },
     "backgroundContainerError": {
-      "value": "{palette.darkModeGrey}",
+      "value": "{palette.neutral800}",
       "type": "color",
-      "description": "darkModeGrey"
+      "description": "neutral800"
     },
     "backgroundContainerHover": {
       "value": "rgba({palette.white}, 0.05)",
@@ -804,9 +799,9 @@
       "description": "white"
     },
     "backgroundContainerBrand": {
-      "value": "{palette.darkModeGrey}",
+      "value": "{palette.neutral800}",
       "type": "color",
-      "description": "darkModeGrey"
+      "description": "neutral800"
     },
     "backgroundContainerBrandHover": {
       "value": "rgba({palette.white}, 0.03)",
@@ -819,99 +814,99 @@
       "description": "white"
     },
     "backgroundContainerBrandOverInverse": {
-      "value": "{palette.darkModeGrey}",
+      "value": "{palette.neutral800}",
       "type": "color",
-      "description": "darkModeGrey"
+      "description": "neutral800"
     },
     "backgroundContainerAlternative": {
-      "value": "{palette.darkModeGrey}",
+      "value": "{palette.neutral800}",
       "type": "color",
-      "description": "darkModeGrey"
+      "description": "neutral800"
     },
     "backgroundOverlay": {
-      "value": "rgba({palette.darkModeGrey}, 0.8)",
+      "value": "rgba({palette.neutral800}, 0.8)",
       "type": "color",
-      "description": "darkModeGrey"
+      "description": "neutral800"
     },
     "backgroundSkeleton": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "backgroundSkeletonInverse": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "backgroundBrandTop": {
-      "value": "{palette.darkModeBlack}",
+      "value": "{palette.neutral900}",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "backgroundBrandBottom": {
-      "value": "{palette.darkModeBlack}",
+      "value": "{palette.neutral900}",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "appBarBackground": {
-      "value": "{palette.darkModeGrey}",
+      "value": "{palette.neutral800}",
       "type": "color",
-      "description": "darkModeGrey"
+      "description": "neutral800"
     },
     "navigationBarBackground": {
-      "value": "{palette.darkModeBlack}",
+      "value": "{palette.neutral900}",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "skeletonWave": {
-      "value": "{palette.grey5}",
+      "value": "{palette.neutral600}",
       "type": "color",
-      "description": "grey5"
+      "description": "neutral600"
     },
     "borderLow": {
-      "value": "{palette.darkModeBlack}",
+      "value": "{palette.neutral900}",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "border": {
-      "value": "{palette.darkModeGrey}",
+      "value": "{palette.neutral800}",
       "type": "color",
-      "description": "darkModeGrey"
+      "description": "neutral800"
     },
     "borderHigh": {
-      "value": "{palette.grey5}",
+      "value": "{palette.neutral600}",
       "type": "color",
-      "description": "grey5"
+      "description": "neutral600"
     },
     "borderSelected": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "coverBackgroundHover": {
-      "value": "rgba({palette.darkModeBlack}, 0.25)",
+      "value": "rgba({palette.neutral900}, 0.25)",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "coverBackgroundPressed": {
-      "value": "rgba({palette.darkModeBlack}, 0.35)",
+      "value": "rgba({palette.neutral900}, 0.35)",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "buttonDangerBackground": {
-      "value": "{palette.pepper}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pepper"
+      "description": "vivoPink500"
     },
     "buttonDangerBackgroundPressed": {
-      "value": "{palette.pepperDark}",
+      "value": "{palette.vivoPink700}",
       "type": "color",
-      "description": "pepperDark"
+      "description": "vivoPink700"
     },
     "buttonDangerBackgroundHover": {
-      "value": "{palette.pepperDark}",
+      "value": "{palette.vivoPink700}",
       "type": "color",
-      "description": "pepperDark"
+      "description": "vivoPink700"
     },
     "buttonLinkDangerBackgroundPressed": {
       "value": "rgba({palette.white}, 0.08)",
@@ -939,29 +934,29 @@
       "description": "white"
     },
     "buttonPrimaryBackground": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurpleLight80"
+      "description": "vivoPurple700"
     },
     "buttonPrimaryBackgroundInverse": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurpleLight80"
+      "description": "vivoPurple700"
     },
     "buttonPrimaryBackgroundPressed": {
-      "value": "{palette.vivoPurpleDark}",
+      "value": "{palette.vivoPurple900}",
       "type": "color",
-      "description": "vivoPurpleDark"
+      "description": "vivoPurple900"
     },
     "buttonPrimaryBackgroundHover": {
-      "value": "{palette.vivoPurpleDark}",
+      "value": "{palette.vivoPurple900}",
       "type": "color",
-      "description": "vivoPurpleDark"
+      "description": "vivoPurple900"
     },
     "buttonPrimaryBackgroundInversePressed": {
-      "value": "{palette.vivoPurpleDark}",
+      "value": "{palette.vivoPurple900}",
       "type": "color",
-      "description": "vivoPurpleDark"
+      "description": "vivoPurple900"
     },
     "buttonSecondaryBackgroundHover": {
       "value": "rgba({palette.white}, 0.15)",
@@ -1004,139 +999,134 @@
       "description": "white"
     },
     "textButtonPrimary": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "textButtonPrimaryInverse": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "textButtonPrimaryInversePressed": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "textButtonSecondary": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "textButtonSecondaryPressed": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "textButtonSecondaryInverse": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "textButtonSecondaryInversePressed": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "textLink": {
-      "value": "{palette.vivoPurpleLight50}",
+      "value": "{palette.vivoPurple400}",
       "type": "color",
-      "description": "vivoPurpleLight50"
+      "description": "vivoPurple400"
     },
     "textLinkInverse": {
-      "value": "{palette.vivoPurpleLight50}",
+      "value": "{palette.vivoPurple400}",
       "type": "color",
-      "description": "vivoPurpleLight50"
+      "description": "vivoPurple400"
     },
     "textLinkDanger": {
-      "value": "{palette.pepper}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pepper"
+      "description": "vivoPink500"
     },
     "textLinkSnackbar": {
-      "value": "{palette.vivoPurpleLight50}",
+      "value": "{palette.vivoPurple400}",
       "type": "color",
-      "description": "vivoPurpleLight50"
+      "description": "vivoPurple400"
     },
     "textActivated": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurpleLight80"
+      "description": "vivoPurple700"
     },
     "textBrand": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurpleLight80"
-    },
-    "inputBorder": {
-      "value": "{palette.darkModeGrey5}",
-      "type": "color",
-      "description": "darkModeGrey5"
+      "description": "vivoPurple700"
     },
     "control": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "controlActivated": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurpleLight80"
+      "description": "vivoPurple700"
     },
     "controlInverse": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "controlActivatedInverse": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurpleLight80"
+      "description": "vivoPurple700"
     },
     "controlError": {
-      "value": "{palette.pepper}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pepper"
+      "description": "vivoPink500"
     },
     "barTrack": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "barTrackInverse": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "loadingBar": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurpleLight80"
+      "description": "vivoPurple700"
     },
     "loadingBarBackground": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "toggleAndroidInactive": {
-      "value": "{palette.grey4}",
+      "value": "{palette.neutral500}",
       "type": "color",
-      "description": "grey4"
+      "description": "neutral500"
     },
     "toggleAndroidBackgroundActive": {
-      "value": "{palette.vivoPurpleLight50}",
+      "value": "{palette.vivoPurple400}",
       "type": "color",
-      "description": "vivoPurpleLight50"
+      "description": "vivoPurple400"
     },
     "iosControlKnob": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "controlKnobInverse": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "divider": {
       "value": "rgba({palette.white}, 0.05)",
@@ -1149,29 +1139,29 @@
       "description": "white"
     },
     "navigationBarDivider": {
-      "value": "{palette.darkModeBlack}",
+      "value": "{palette.neutral900}",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "badge": {
-      "value": "{palette.pepperDark}",
+      "value": "{palette.vivoPink700}",
       "type": "color",
-      "description": "pepperDark"
+      "description": "vivoPink700"
     },
     "feedbackErrorBackground": {
-      "value": "{palette.pepper}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pepper"
+      "description": "vivoPink500"
     },
     "feedbackInfoBackground": {
-      "value": "{palette.grey6}",
+      "value": "{palette.black}",
       "type": "color",
-      "description": "grey6"
+      "description": "black"
     },
     "brand": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurpleLight80"
+      "description": "vivoPurple700"
     },
     "brandHigh": {
       "value": "rgba({palette.white}, 0.05)",
@@ -1179,329 +1169,329 @@
       "description": "white"
     },
     "inverse": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "neutralHigh": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "neutralMedium": {
-      "value": "{palette.grey5}",
+      "value": "{palette.neutral600}",
       "type": "color",
-      "description": "grey5"
+      "description": "neutral600"
     },
     "neutralMediumInverse": {
-      "value": "{palette.grey5}",
+      "value": "{palette.neutral600}",
       "type": "color",
-      "description": "grey5"
+      "description": "neutral600"
     },
     "neutralLow": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "neutralLowAlternative": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "textPrimary": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "textPrimaryInverse": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "textSecondary": {
-      "value": "{palette.grey3}",
+      "value": "{palette.neutral500}",
       "type": "color",
-      "description": "grey3"
+      "description": "neutral500"
     },
     "textSecondaryInverse": {
-      "value": "{palette.grey3}",
+      "value": "{palette.neutral500}",
       "type": "color",
-      "description": "grey3"
+      "description": "neutral500"
     },
     "success": {
-      "value": "{palette.vivoGreen}",
+      "value": "{palette.vivoGreen500}",
       "type": "color",
-      "description": "vivoGreen"
+      "description": "vivoGreen500"
     },
     "warning": {
-      "value": "{palette.orange}",
+      "value": "{palette.vivoOrange500}",
       "type": "color",
-      "description": "orange"
+      "description": "vivoOrange500"
     },
     "error": {
-      "value": "{palette.pepper}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pepper"
+      "description": "vivoPink500"
     },
     "textError": {
-      "value": "{palette.pepper}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pepper"
+      "description": "vivoPink500"
     },
     "textErrorInverse": {
-      "value": "{palette.pepper}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pepper"
+      "description": "vivoPink500"
     },
     "promo": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurpleLight80"
+      "description": "vivoPurple700"
     },
     "highlight": {
-      "value": "{palette.pink}",
+      "value": "{palette.vivoPink500}",
       "type": "color",
-      "description": "pink"
+      "description": "vivoPink500"
     },
     "successLow": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "warningLow": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "errorLow": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "promoLow": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "brandLow": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "successHigh": {
-      "value": "{palette.vivoGreenLight30}",
+      "value": "{palette.vivoGreen400}",
       "type": "color",
-      "description": "vivoGreenLight30"
+      "description": "vivoGreen400"
     },
     "warningHigh": {
-      "value": "{palette.orangeLight40}",
+      "value": "{palette.vivoOrange400}",
       "type": "color",
-      "description": "orangeLight40"
+      "description": "vivoOrange400"
     },
     "errorHigh": {
-      "value": "{palette.pepperLight40}",
+      "value": "{palette.vivoPink400}",
       "type": "color",
-      "description": "pepperLight40"
+      "description": "vivoPink400"
     },
     "promoHigh": {
-      "value": "{palette.vivoPurpleLight50}",
+      "value": "{palette.vivoPurple400}",
       "type": "color",
-      "description": "vivoPurpleLight50"
+      "description": "vivoPurple400"
     },
     "successHighInverse": {
-      "value": "{palette.vivoGreenDark}",
+      "value": "{palette.vivoGreen900}",
       "type": "color",
-      "description": "vivoGreenDark"
+      "description": "vivoGreen900"
     },
     "warningHighInverse": {
-      "value": "{palette.orangeDark}",
+      "value": "{palette.vivoOrange800}",
       "type": "color",
-      "description": "orangeDark"
+      "description": "vivoOrange800"
     },
     "errorHighInverse": {
-      "value": "{palette.pepperDark80}",
+      "value": "{palette.vivoPink800}",
       "type": "color",
-      "description": "pepperDark80"
+      "description": "vivoPink800"
     },
     "promoHighInverse": {
-      "value": "{palette.vivoPurple}",
+      "value": "{palette.vivoPurple800}",
       "type": "color",
-      "description": "vivoPurple"
+      "description": "vivoPurple800"
     },
     "textNavigationBarPrimary": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "textNavigationBarSecondary": {
-      "value": "{palette.grey4}",
+      "value": "{palette.neutral500}",
       "type": "color",
-      "description": "grey4"
+      "description": "neutral500"
     },
     "textNavigationSearchBarHint": {
-      "value": "{palette.grey4}",
+      "value": "{palette.neutral500}",
       "type": "color",
-      "description": "grey4"
+      "description": "neutral500"
     },
     "textNavigationSearchBarText": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "textAppBar": {
-      "value": "{palette.grey5}",
+      "value": "{palette.neutral600}",
       "type": "color",
-      "description": "grey5"
+      "description": "neutral600"
     },
     "textAppBarSelected": {
-      "value": "{palette.grey2}",
+      "value": "{palette.neutral200}",
       "type": "color",
-      "description": "grey2"
+      "description": "neutral200"
     },
     "customTabsBackground": {
-      "value": "{palette.darkModeBlack}",
+      "value": "{palette.neutral900}",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "neutral900"
     },
     "tagTextPromo": {
-      "value": "{palette.vivoPurpleLight50}",
+      "value": "{palette.vivoPurple400}",
       "type": "color",
-      "description": "vivoPurpleLight50"
+      "description": "vivoPurple400"
     },
     "tagTextActive": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurpleLight80"
+      "description": "vivoPurple700"
     },
     "tagTextInactive": {
-      "value": "{palette.grey5}",
+      "value": "{palette.neutral600}",
       "type": "color",
-      "description": "grey5"
+      "description": "neutral600"
     },
     "tagTextInfo": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurpleLight80"
+      "description": "vivoPurple700"
     },
     "tagTextSuccess": {
-      "value": "{palette.vivoGreenLight30}",
+      "value": "{palette.vivoGreen400}",
       "type": "color",
-      "description": "vivoGreenLight30"
+      "description": "vivoGreen400"
     },
     "tagTextWarning": {
-      "value": "{palette.orangeLight40}",
+      "value": "{palette.vivoOrange400}",
       "type": "color",
-      "description": "orangeLight40"
+      "description": "vivoOrange400"
     },
     "tagTextError": {
-      "value": "{palette.pepperLight40}",
+      "value": "{palette.vivoPink400}",
       "type": "color",
-      "description": "pepperLight40"
+      "description": "vivoPink400"
     },
     "tagBackgroundPromo": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "tagBackgroundActive": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "tagBackgroundInactive": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "tagBackgroundInfo": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "tagBackgroundSuccess": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "tagBackgroundWarning": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "tagBackgroundError": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "tagTextPromoInverse": {
-      "value": "{palette.vivoPurpleLight50}",
+      "value": "{palette.vivoPurple400}",
       "type": "color",
-      "description": "vivoPurpleLight50"
+      "description": "vivoPurple400"
     },
     "tagTextActiveInverse": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurpleLight80"
+      "description": "vivoPurple700"
     },
     "tagTextInactiveInverse": {
-      "value": "{palette.grey5}",
+      "value": "{palette.neutral600}",
       "type": "color",
-      "description": "grey5"
+      "description": "neutral600"
     },
     "tagTextInfoInverse": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurple700}",
       "type": "color",
-      "description": "vivoPurpleLight80"
+      "description": "vivoPurple700"
     },
     "tagTextSuccessInverse": {
-      "value": "{palette.vivoGreenLight30}",
+      "value": "{palette.vivoGreen400}",
       "type": "color",
-      "description": "vivoGreenLight30"
+      "description": "vivoGreen400"
     },
     "tagTextWarningInverse": {
-      "value": "{palette.orangeLight40}",
+      "value": "{palette.vivoOrange400}",
       "type": "color",
-      "description": "orangeLight40"
+      "description": "vivoOrange400"
     },
     "tagTextErrorInverse": {
-      "value": "{palette.pepperLight40}",
+      "value": "{palette.vivoPink400}",
       "type": "color",
-      "description": "pepperLight40"
+      "description": "vivoPink400"
     },
     "tagBackgroundPromoInverse": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "tagBackgroundActiveInverse": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "tagBackgroundInactiveInverse": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "tagBackgroundInfoInverse": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "tagBackgroundSuccessInverse": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "tagBackgroundWarningInverse": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "tagBackgroundErrorInverse": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "{palette.neutral700}",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "neutral700"
     },
     "cardContentOverlay": {
       "type": "linear-gradient",
@@ -1509,20 +1499,20 @@
         "angle": 180,
         "colors": [
           {
-            "value": "rgba({palette.grey6}, 0)",
+            "value": "rgba({palette.black}, 0)",
             "stop": 0
           },
           {
-            "value": "rgba({palette.grey6}, 0.4)",
+            "value": "rgba({palette.black}, 0.4)",
             "stop": 0.3
           },
           {
-            "value": "rgba({palette.grey6}, 0.7)",
+            "value": "rgba({palette.black}, 0.7)",
             "stop": 1
           }
         ]
       },
-      "description": "grey6"
+      "description": "black"
     }
   },
   "radius": {
@@ -1819,148 +1809,212 @@
   },
   "global": {
     "palette": {
-      "vivoPurple": {
+      "vivoPurple50": {
+        "value": "#F9F3FF",
+        "type": "color"
+      },
+      "vivoPurple100": {
+        "value": "#F3E6FF",
+        "type": "color"
+      },
+      "vivoPurple200": {
+        "value": "#E7CBFF",
+        "type": "color"
+      },
+      "vivoPurple300": {
+        "value": "#DAABFF",
+        "type": "color"
+      },
+      "vivoPurple400": {
+        "value": "#CC84FF",
+        "type": "color"
+      },
+      "vivoPurple500": {
+        "value": "#BD4AFF",
+        "type": "color"
+      },
+      "vivoPurple600": {
+        "value": "#AE42E4",
+        "type": "color"
+      },
+      "vivoPurple700": {
+        "value": "#8833B2",
+        "type": "color"
+      },
+      "vivoPurple800": {
         "value": "#660099",
         "type": "color"
       },
-      "vivoPurpleDark": {
-        "value": "#461E5F",
+      "vivoPurple900": {
+        "value": "#380054",
         "type": "color"
       },
-      "vivoPurpleLight10": {
-        "value": "#EFE5F4",
+      "vivoPink50": {
+        "value": "#FDF3F6",
         "type": "color"
       },
-      "vivoPurpleLight20": {
-        "value": "#E0CCEB",
+      "vivoPink100": {
+        "value": "#FBE6EC",
         "type": "color"
       },
-      "vivoPurpleLight50": {
-        "value": "#B280CC",
+      "vivoPink200": {
+        "value": "#F7C9D5",
         "type": "color"
       },
-      "vivoPurpleLight80": {
-        "value": "#8433AD",
+      "vivoPink300": {
+        "value": "#ff96b2",
         "type": "color"
       },
-      "vivoPurpleLight90": {
-        "value": "#751AA3",
+      "vivoPink400": {
+        "value": "#EF7E9C",
         "type": "color"
       },
-      "vivoGreen": {
-        "value": "#99CC33",
+      "vivoPink500": {
+        "value": "#EB3C7D",
         "type": "color"
       },
-      "vivoGreenDark": {
-        "value": "#225C3D",
+      "vivoPink600": {
+        "value": "#CC3D70",
         "type": "color"
       },
-      "vivoGreenLight10": {
-        "value": "#EDF8E8",
+      "vivoPink700": {
+        "value": "#B62E5E",
         "type": "color"
       },
-      "vivoGreen25": {
-        "value": "#D6EBAD",
+      "vivoPink800": {
+        "value": "#95264D",
         "type": "color"
       },
-      "vivoGreenLight30": {
-        "value": "#91AE9E",
+      "vivoPink900": {
+        "value": "#691B36",
         "type": "color"
       },
-      "vivoBlue": {
-        "value": "#00ABDB",
+      "vivoGreen50": {
+        "value": "#F7FBF2",
         "type": "color"
       },
-      "orange": {
-        "value": "#FF9900",
+      "vivoGreen100": {
+        "value": "#EFF7E4",
         "type": "color"
       },
-      "orange25": {
-        "value": "#FFD699",
+      "vivoGreen200": {
+        "value": "#DDEFC6",
         "type": "color"
       },
-      "orangeDark": {
-        "value": "#972A1D",
+      "vivoGreen300": {
+        "value": "#C8E6A1",
         "type": "color"
       },
-      "orangeLight10": {
-        "value": "#FFEFE1",
+      "vivoGreen400": {
+        "value": "#B2D682",
         "type": "color"
       },
-      "orangeLight40": {
+      "vivoGreen500": {
+        "value": "#82D400",
+        "type": "color"
+      },
+      "vivoGreen600": {
+        "value": "#3FBE00",
+        "type": "color"
+      },
+      "vivoGreen700": {
+        "value": "#37A400",
+        "type": "color"
+      },
+      "vivoGreen800": {
+        "value": "#2D8600",
+        "type": "color"
+      },
+      "vivoGreen900": {
+        "value": "#205F00",
+        "type": "color"
+      },
+      "vivoOrange50": {
+        "value": "#FFFAF2",
+        "type": "color"
+      },
+      "vivoOrange100": {
+        "value": "#FFF4E4",
+        "type": "color"
+      },
+      "vivoOrange200": {
+        "value": "#FFE8C6",
+        "type": "color"
+      },
+      "vivoOrange300": {
+        "value": "#FFD9A1",
+        "type": "color"
+      },
+      "vivoOrange400": {
         "value": "#FFB84C",
         "type": "color"
       },
-      "pink": {
-        "value": "#EB3D7D",
+      "vivoOrange500": {
+        "value": "#FF9900",
         "type": "color"
       },
-      "pepper": {
-        "value": "#CC1F59",
+      "vivoOrange600": {
+        "value": "#E47200",
         "type": "color"
       },
-      "pepperDark": {
-        "value": "#B71D63",
+      "vivoOrange700": {
+        "value": "#C65300",
         "type": "color"
       },
-      "pepperDark80": {
-        "value": "#8F2052",
+      "vivoOrange800": {
+        "value": "#A13600",
         "type": "color"
       },
-      "pepperLight10": {
-        "value": "#FCE4EF",
+      "vivoOrange900": {
+        "value": "#721D00",
         "type": "color"
       },
-      "pepperLight30": {
-        "value": "#F7B1CB",
+      "neutral50": {
+        "value": "#FAFAFA",
         "type": "color"
       },
-      "pepperLight40": {
-        "value": "#DB628B",
-        "type": "color"
-      },
-      "grey1": {
+      "neutral100": {
         "value": "#F6F6F6",
         "type": "color"
       },
-      "grey2": {
+      "neutral200": {
         "value": "#EEEEEE",
         "type": "color"
       },
-      "grey3": {
+      "neutral300": {
         "value": "#DDDDDD",
         "type": "color"
       },
-      "grey4": {
-        "value": "#8A8C90",
+      "neutral400": {
+        "value": "#BBBBBB",
         "type": "color"
       },
-      "grey5": {
+      "neutral500": {
+        "value": "#949494",
+        "type": "color"
+      },
+      "neutral600": {
         "value": "#666666",
         "type": "color"
       },
-      "grey6": {
-        "value": "#000000",
+      "neutral700": {
+        "value": "#313235",
+        "type": "color"
+      },
+      "neutral800": {
+        "value": "#242424",
+        "type": "color"
+      },
+      "neutral900": {
+        "value": "#191919",
         "type": "color"
       },
       "white": {
         "value": "#FFFFFF",
         "type": "color"
       },
-      "darkModeBlack": {
-        "value": "#191919",
-        "type": "color"
-      },
-      "darkModeGrey": {
-        "value": "#242424",
-        "type": "color"
-      },
-      "darkModeGrey5": {
-        "value": "#6D7D88",
-        "type": "color"
-      },
-      "darkModeGrey6": {
-        "value": "#313235",
+      "black": {
+        "value": "#000000",
         "type": "color"
       }
     }


### PR DESCRIPTION
Updated the tagBackgroundActive color token at Vivo New token sheet. We changed it from `palette.vivoPurple100` color to `palette.neutral100`. En la antigua versión, si lo considerais, se cambiaría de `vivoPurpleLight10` para `grey1`.