### PR TITLE
fix(skin): Update tagBackgroundActive color on Vivo New token sheet

### DIFF
--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -641,9 +641,9 @@
       "description": "vivoPurpleLight10"
     },
     "tagBackgroundActive": {
-      "value": "{palette.vivoPurpleLight10}",
+      "value": "{palette.grey1}",
       "type": "color",
-      "description": "vivoPurpleLight10"
+      "description": "grey1"
     },
     "tagBackgroundInactive": {
       "value": "{palette.grey1}",


### PR DESCRIPTION
Updated the tagBackgroundActive color token at Vivo New token sheet. We changed it from `palette.vivoPurpleLight10` color to `palette.grey1`.