### PR TITLE
Update textBrand token in Blau

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -311,9 +311,9 @@
       "description": "blauBlueSecondary"
     },
     "textBrand": {
-      "value": "{palette.blauBluePrimary}",
+      "value": "{palette.blauBlueSecondary}",
       "type": "color",
-      "description": "blauBluePrimary"
+      "description": "blauBlueSecondary"
     },
     "inputBorder": {
       "value": "{palette.grey4}",


### PR DESCRIPTION
The current value of the textBrand token is causing the icon and initials in Blau avatar component to fail AA contrast against avatar's background.