### PR TITLE
feat(skin): card overlay to black in O2 new

### DIFF
--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -878,25 +878,25 @@
         "angle": 180,
         "colors": [
           {
-            "value": "rgba({palette.beyondBlue}, 0)",
+            "value": "rgba({palette.black}, 0)",
             "stop": 0
           },
           {
-            "value": "rgba({palette.beyondBlue}, 0.4)",
+            "value": "rgba({palette.black}, 0.4)",
             "stop": 0.3
           },
           {
-            "value": "rgba({palette.beyondBlue}, 1)",
+            "value": "rgba({palette.black}, 1)",
             "stop": 1
           }
         ]
       },
-      "description": "grey6"
+      "description": "black"
     },
     "cardFooterOverlay": {
-      "value": "rgba({palette.beyondBlue}, 1)",
+      "value": "rgba({palette.black}, 1)",
       "type": "color",
-      "description": "beyondBlue"
+      "description": "black"
     }
   },
   "dark": {

--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -886,7 +886,7 @@
             "stop": 0.3
           },
           {
-            "value": "rgba({palette.black}, 1)",
+            "value": "rgba({palette.black}, 0.7)",
             "stop": 1
           }
         ]


### PR DESCRIPTION
According to guidelines, blue color in overlay is only allow for third parties contents. Black will be the default color with the possibility to use beyondBlue through property in cover cards