### PR TITLE
feat(skin): Fix o2-new footer overlay color in lighy mode

### DIFF
--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -894,7 +894,7 @@
       "description": "black"
     },
     "cardFooterOverlay": {
-      "value": "rgba({palette.black}, 1)",
+      "value": "rgba({palette.black}, 0.7)",
       "type": "color",
       "description": "black"
     }


### PR DESCRIPTION
Addresses the issue of the footer overlay color in our application. The previous color setting for the `cardFooterOverlay` was set to fully opaque black (`rgba({palette.black}, 1)`), which made it difficult for users to see underlying content and negatively impacted overall usability and aesthetics.

By adjusting the opacity to 0.7 (`rgba({palette.black}, 0.7)`), we enhance the visual hierarchy and improve the user experience by allowing more of the background content to be visible while still providing a subtle overlay effect. This change creates a better balance between the footer and the content above it, making the interface more user-friendly and visually appealing.

Overall, this update improves the design consistency and accessibility of the application.