### PR TITLE
feat(skin): Add tag border radii token

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -1785,6 +1785,10 @@
       "value": "24",
       "type": "borderRadius"
     },
+    "tag": {
+      "value": "24",
+      "type": "borderRadius"
+    },
     "input": {
       "value": "8",
       "type": "borderRadius"

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -1816,6 +1816,10 @@
       "value": "8",
       "type": "borderRadius"
     },
+    "tag": {
+      "value": "8",
+      "type": "borderRadius"
+    },
     "input": {
       "value": "16",
       "type": "borderRadius"

--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -1777,11 +1777,15 @@
       "type": "borderRadius"
     },
     "indicator": {
-      "value": "0",
+      "value": "24",
       "type": "borderRadius"
     },
     "chip": {
       "value": "24",
+      "type": "borderRadius"
+    },
+    "tag": {
+      "value": "0",
       "type": "borderRadius"
     },
     "input": {

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -1784,6 +1784,10 @@
       "value": "24",
       "type": "borderRadius"
     },
+    "tag": {
+      "value": "24",
+      "type": "borderRadius"
+    },
     "input": {
       "value": "12",
       "type": "borderRadius"

--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -1816,6 +1816,10 @@
       "value": "24",
       "type": "borderRadius"
     },
+    "tag": {
+      "value": "24",
+      "type": "borderRadius"
+    },
     "input": {
       "value": "12",
       "type": "borderRadius"

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -1785,6 +1785,10 @@
       "value": "24",
       "type": "borderRadius"
     },
+    "tag": {
+      "value": "24",
+      "type": "borderRadius"
+    },
     "input": {
       "value": "8",
       "type": "borderRadius"

--- a/tokens/schema/skin-schema.json
+++ b/tokens/schema/skin-schema.json
@@ -425,6 +425,7 @@
         "container": { "$ref": "#/definitions/radiusProperties" },
         "indicator": { "$ref": "#/definitions/radiusProperties" },
         "chip": { "$ref": "#/definitions/radiusProperties" },
+        "tag": { "$ref": "#/definitions/radiusProperties" },
         "input": { "$ref": "#/definitions/radiusProperties" },
         "legacyDisplay": { "$ref": "#/definitions/radiusProperties" },
         "popup": { "$ref": "#/definitions/radiusProperties" },

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -1784,6 +1784,10 @@
       "value": "24",
       "type": "borderRadius"
     },
+    "tag": {
+      "value": "24",
+      "type": "borderRadius"
+    },
     "input": {
       "value": "0",
       "type": "borderRadius"

--- a/tokens/tu.json
+++ b/tokens/tu.json
@@ -1784,6 +1784,10 @@
       "value": "24",
       "type": "borderRadius"
     },
+    "tag": {
+      "value": "24",
+      "type": "borderRadius"
+    },
     "input": {
       "value": "12",
       "type": "borderRadius"

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -1784,6 +1784,10 @@
       "value": "24",
       "type": "borderRadius"
     },
+    "tag": {
+      "value": "24",
+      "type": "borderRadius"
+    },
     "input": {
       "value": "12",
       "type": "borderRadius"

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -1784,6 +1784,10 @@
       "value": "24",
       "type": "borderRadius"
     },
+    "tag": {
+      "value": "24",
+      "type": "borderRadius"
+    },
     "input": {
       "value": "8",
       "type": "borderRadius"


### PR DESCRIPTION
### Pull Request Description: Add Tag Border Radii Token

This pull request introduces a new border radius token specifically for tags across multiple token files. The addition of the "tag" border radius token enhances our design consistency and allows for better customization in UI components.

#### Motivation for Change
- **Consistency**: By defining a border radius for tags, we ensure that all UI elements have a cohesive look and feel, aligning with the overall design language of our project.
- **Flexibility**: Providing a dedicated token for tag border radii allows designers and developers to easily adjust the styling of tags without affecting other components.
- **Improved Styling**: Tags are a common UI element, and having a specific border radius will improve their appearance, making them visually appealing and enhancing user experience.

#### Changes Made
- Added a "tag" border radius token with a value of "24" in relevant token files, including `blau.json`, `esimflag.json`, `movistar-new.json`, `movistar.json`, `o2-new.json`, `o2.json`, `telefonica.json`, `tu.json`, `vivo-new.json`, and `vivo.json`.
- Updated the schema definition in `skin-schema.json` to include the new "tag" property.

This addition is expected to improve our project's design consistency and make it easier to maintain visual standards across different components.