### PR TITLE
Update textButtonPrimaryMedia in o2-new

### DIFF
--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -338,9 +338,9 @@
       "description": "beyondBlue"
     },
     "textButtonPrimaryMedia": {
-      "value": "{palette.white}",
+      "value": "{palette.beyondBlue}",
       "type": "color",
-      "description": "white"
+      "description": "beyondBlue"
     },
     "textButtonPrimaryInversePressed": {
       "value": "{palette.beyondBlue70}",
@@ -1216,9 +1216,9 @@
       "description": "white"
     },
     "textButtonPrimaryMedia": {
-      "value": "{palette.white}",
+      "value": "{palette.beyondBlue}",
       "type": "color",
-      "description": "white"
+      "description": "beyondBlue"
     },
     "textButtonPrimaryInversePressed": {
       "value": "{palette.white}",


### PR DESCRIPTION
### Pull Request Description: Update textButtonPrimaryMedia in o2-new

This pull request updates the `textButtonPrimaryMedia` color value in the `o2-new` design tokens from `{palette.white}` to `{palette.beyondBlue}`. 

**Motivation:**
The change is motivated by a design decision to enhance visual consistency and branding by aligning the primary media button color with our current theme. The use of `beyondBlue` instead of `white` is intended to improve visibility and user engagement, as it better reflects our brand identity.

**Improvements:**
1. **Brand Alignment:** This update ensures that our UI components are more consistent with our branding guidelines.
2. **User Experience:** The new color choice is expected to enhance the visibility of the primary media button, making it more prominent and user-friendly.
3. **Consistency Across Components:** The change standardizes the color usage across various components that utilize the `textButtonPrimaryMedia` token.

Overall, this update is a step towards improving our UI's coherence and ensuring that it meets our design standards.