### PR TITLE
Add movistar-new to sync-figma-tokens

### DIFF
--- a/.github/workflows/sync-figma-tokens.yml
+++ b/.github/workflows/sync-figma-tokens.yml
@@ -7,6 +7,7 @@ on:
       - production
     paths:
       - "tokens/movistar.json"
+      - "tokens/movistar-new.json"
       - "tokens/vivo-new.json"
       - "tokens/o2-new.json"
       - "tokens/telefonica.json"


### PR DESCRIPTION
### Pull Request Description: Add movistar-new to sync-figma-tokens

This pull request introduces the `movistar-new.json` token file to the Figma token synchronization workflow. By adding this file, we ensure that any updates made to the Movistar design tokens are automatically synchronized with Figma whenever changes are detected.

**Motivation:**
The inclusion of `movistar-new.json` is crucial for maintaining consistency across design and development. This file contains updated design tokens that reflect the latest branding and styling guidelines for Movistar. By syncing these tokens, we can ensure that our design team has access to the most current assets, which enhances collaboration and streamlines the design process.

**Improvements:**
- **Consistency:** Ensures that the design tokens used in Figma are always in line with the latest updates.
- **Efficiency:** Reduces the manual effort required to keep design assets updated, allowing the team to focus on other critical tasks.
- **Collaboration:** Facilitates better communication between design and development teams by providing a single source of truth for design tokens.

Overall, this change enhances our workflow and improves the quality of our design assets, ultimately leading to a better product.