### PR TITLE
fix(icons): use old iconset in old movistar skin 

### DIFF
--- a/tokens/figma/variables.mjs
+++ b/tokens/figma/variables.mjs
@@ -19,7 +19,7 @@ export const FONT_FAMILIES = {
 };
 
 export const ICON_SETS = {
-  [BRANDS.MOVISTAR]: "Default",
+  [BRANDS.MOVISTAR]: "Vivo",
   [BRANDS.MOVISTAR_NEW]: "Default",
   [BRANDS.VIVO_NEW]: "Vivo",
   [BRANDS.O2_NEW]: "O2",


### PR DESCRIPTION
This is a temporary use for Movistar old skin to avoid new icons in this brand