### PR TITLE
fix(icons): use movistar old iconset in old movistar skin

### DIFF
--- a/tokens/figma/variables.mjs
+++ b/tokens/figma/variables.mjs
@@ -19,7 +19,7 @@ export const FONT_FAMILIES = {
 };
 
 export const ICON_SETS = {
-  [BRANDS.MOVISTAR]: "Vivo",
+  [BRANDS.MOVISTAR]: "Movistar",
   [BRANDS.MOVISTAR_NEW]: "Default",
   [BRANDS.VIVO_NEW]: "Vivo",
   [BRANDS.O2_NEW]: "O2",

--- a/tokens/figma/variables.mjs
+++ b/tokens/figma/variables.mjs
@@ -19,7 +19,7 @@ export const FONT_FAMILIES = {
 };
 
 export const ICON_SETS = {
-  [BRANDS.MOVISTAR]: "Default",
+  [BRANDS.MOVISTAR]: "Vivo",
   [BRANDS.MOVISTAR_NEW]: "Default",
   [BRANDS.VIVO_NEW]: "Vivo",
   [BRANDS.O2_NEW]: "O2",


### PR DESCRIPTION
Addresses an inconsistency in our icon set configuration for the Movistar brand. The change updates the icon set used for the old Movistar skin from "Vivo" to "Movistar." 

The motivation behind this change is to ensure brand consistency and accuracy in our design system. By using the correct icon set, we maintain the integrity of the Movistar brand identity, which is crucial for user recognition and experience.

Implementing this fix will enhance our project's visual consistency and align our assets with the intended branding, ultimately improving the overall user interface for users interacting with the old Movistar skin.