### PR TITLE
fix(movistar new): hover and tags colors

### DIFF
--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -276,9 +276,9 @@
       "description": "blueHigh"
     },
     "buttonPrimaryBackgroundInverseHover": {
-      "value": "{palette.blue100}",
+      "value": "{palette.blue200}",
       "type": "color",
-      "description": "blue100"
+      "description": "blue200"
     },
     "buttonPrimaryBackgroundNegativeHover": {
       "value": "{palette.blue100}",
@@ -291,9 +291,9 @@
       "description": "blue100"
     },
     "buttonPrimaryBackgroundMediaHover": {
-      "value": "{palette.blue100}",
+      "value": "{palette.blue200}",
       "type": "color",
-      "description": "blue100"
+      "description": "blue200"
     },
     "buttonPrimaryBackgroundPressed": {
       "value": "{palette.blueHigh}",
@@ -301,9 +301,9 @@
       "description": "blueHigh"
     },
     "buttonPrimaryBackgroundInversePressed": {
-      "value": "{palette.blue100}",
+      "value": "{palette.blue200}",
       "type": "color",
-      "description": "blue100"
+      "description": "blue200"
     },
     "buttonPrimaryBackgroundNegativePressed": {
       "value": "{palette.blue100}",
@@ -316,9 +316,9 @@
       "description": "blue100"
     },
     "buttonPrimaryBackgroundMediaPressed": {
-      "value": "{palette.blue100}",
+      "value": "{palette.blue200}",
       "type": "color",
-      "description": "blue100"
+      "description": "blue200"
     },
     "buttonSecondaryBackgroundBrand": {
       "value": "rgba({palette.white}, 0)",
@@ -1664,9 +1664,9 @@
       "description": "blue800"
     },
     "buttonPrimaryBackgroundMediaHover": {
-      "value": "{palette.blue100}",
+      "value": "{palette.blue200}",
       "type": "color",
-      "description": "blue100"
+      "description": "blue200"
     },
     "buttonPrimaryBackgroundPressed": {
       "value": "{palette.blue800}",
@@ -1689,9 +1689,9 @@
       "description": "blue800"
     },
     "buttonPrimaryBackgroundMediaPressed": {
-      "value": "{palette.blue100}",
+      "value": "{palette.blue200}",
       "type": "color",
-      "description": "blue100"
+      "description": "blue200"
     },
     "buttonSecondaryBackgroundBrand": {
       "value": "rgba({palette.white}, 0)",

--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -221,9 +221,9 @@
       "description": "salmon100"
     },
     "buttonLinkBackgroundPressed": {
-      "value": "{palette.blue100}",
+      "value": "{palette.blue200}",
       "type": "color",
-      "description": "blue100"
+      "description": "blue200"
     },
     "buttonLinkBackgroundInversePressed": {
       "value": "rgba({palette.white}, 0.3)",
@@ -376,9 +376,9 @@
       "description": "white"
     },
     "buttonSecondaryBackgroundHover": {
-      "value": "{palette.blue100}",
+      "value": "{palette.blue200}",
       "type": "color",
-      "description": "blue100"
+      "description": "blue200"
     },
     "buttonSecondaryBackgroundInverseHover": {
       "value": "rgba({palette.white}, 0.2)",
@@ -401,9 +401,9 @@
       "description": "white"
     },
     "buttonSecondaryBackgroundPressed": {
-      "value": "{palette.blue100}",
+      "value": "{palette.blue200}",
       "type": "color",
-      "description": "blue100"
+      "description": "blue200"
     },
     "buttonSecondaryBackgroundInversePressed": {
       "value": "rgba({palette.white}, 0.3)",
@@ -1106,9 +1106,9 @@
       "description": "redHigh"
     },
     "tagBackgroundActive": {
-      "value": "{palette.blue100}",
+      "value": "{palette.blue200}",
       "type": "color",
-      "description": "blue100"
+      "description": "blue200"
     },
     "tagBackgroundInactive": {
       "value": "{palette.grey200}",
@@ -1116,9 +1116,9 @@
       "description": "grey200"
     },
     "tagBackgroundInfo": {
-      "value": "{palette.blue100}",
+      "value": "{palette.blue200}",
       "type": "color",
-      "description": "blue100"
+      "description": "blue200"
     },
     "tagBackgroundSuccess": {
       "value": "{palette.green200}",


### PR DESCRIPTION
Addresses the color inconsistencies in the Movistar New design system by updating hover and tag colors from `blue100` to `blue200`. 

### Motivation
The previous color scheme used `blue100` for various button and tag states, which did not provide sufficient contrast and visual distinction. By updating these values to `blue200`, we enhance the UI's usability and accessibility, ensuring that hover states and tags are more visually appealing and easier to interact with.

### Improvements
- **Hover States**: The button hover states are now more prominent, allowing users to better recognize interactive elements.
- **Tag Colors**: The tags will now utilize a more vibrant color, improving their visibility and overall aesthetic within the interface.

These changes contribute to a better user experience by ensuring that color usage aligns with design standards and enhances the visual hierarchy of the application.

https://github.com/Telefonica/mistica-ios/pull/485