### PR TITLE
2110 chevronIndicator - new color token

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -655,6 +655,11 @@
       "type": "color",
       "description": "blauRed"
     },
+    "chevronIndicator": {
+      "value": "{palette.grey5}",
+      "type": "color",
+      "description": "grey5"
+    },
     "barTrack": {
       "value": "{palette.grey3}",
       "type": "color",
@@ -2027,6 +2032,11 @@
       "value": "{palette.blauRed}",
       "type": "color",
       "description": "blauRed"
+    },
+    "chevronIndicator": {
+      "value": "{palette.grey4}",
+      "type": "color",
+      "description": "grey4"
     },
     "barTrack": {
       "value": "{palette.grey5}",

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -687,6 +687,11 @@
       "type": "color",
       "description": "tomato"
     },
+    "chevronIndicator": {
+      "value": "{palette.grey5}",
+      "type": "color",
+      "description": "grey5"
+    },
     "barTrack": {
       "value": "{palette.grey3}",
       "type": "color",
@@ -2059,6 +2064,11 @@
       "value": "{palette.tomato55}",
       "type": "color",
       "description": "tomato55"
+    },
+    "chevronIndicator": {
+      "value": "{palette.grey4}",
+      "type": "color",
+      "description": "grey4"
     },
     "barTrack": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -655,6 +655,11 @@
       "type": "color",
       "description": "red"
     },
+    "chevronIndicator": {
+      "value": "{palette.movistarBlue}",
+      "type": "color",
+      "description": "movistarBlue"
+    },
     "barTrack": {
       "value": "{palette.grey300}",
       "type": "color",
@@ -2027,6 +2032,11 @@
       "value": "{palette.red}",
       "type": "color",
       "description": "red"
+    },
+    "chevronIndicator": {
+      "value": "{palette.darkModeMovistarBlue}",
+      "type": "color",
+      "description": "darkModeMovistarBlue"
     },
     "barTrack": {
       "value": "{palette.grey600}",

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -656,9 +656,9 @@
       "description": "pepper55"
     },
     "chevronIndicator": {
-      "value": "{palette.darkModeGrey4}",
+      "value": "{palette.grey5}",
       "type": "color",
-      "description": "darkModeGrey4"
+      "description": "grey5"
     },
     "barTrack": {
       "value": "{palette.grey3}",
@@ -2034,9 +2034,9 @@
       "description": "pepper45"
     },
     "chevronIndicator": {
-      "value": "{palette.darkModeGrey4}",
+      "value": "{palette.darkModeGrey5}",
       "type": "color",
-      "description": "darkModeGrey4"
+      "description": "darkModeGrey5"
     },
     "barTrack": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -651,9 +651,14 @@
       "description": "white"
     },
     "controlError": {
-      "value": "{palette.pepper55}",
+      "value": "{palette.grey4}",
       "type": "color",
-      "description": "pepper55"
+      "description": "grey4"
+    },
+    "chevronIndicator": {
+      "value": "{palette.darkModeGrey4}",
+      "type": "color",
+      "description": "darkModeGrey4"
     },
     "barTrack": {
       "value": "{palette.grey3}",
@@ -2027,6 +2032,11 @@
       "value": "{palette.pepper45}",
       "type": "color",
       "description": "pepper45"
+    },
+    "chevronIndicator": {
+      "value": "{palette.darkModeGrey4}",
+      "type": "color",
+      "description": "darkModeGrey4"
     },
     "barTrack": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -651,9 +651,9 @@
       "description": "white"
     },
     "controlError": {
-      "value": "{palette.grey4}",
+      "value": "{palette.pepper55}",
       "type": "color",
-      "description": "grey4"
+      "description": "pepper55"
     },
     "chevronIndicator": {
       "value": "{palette.darkModeGrey4}",

--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -687,6 +687,11 @@
       "type": "color",
       "description": "o2Red60"
     },
+    "chevronIndicator": {
+      "value": "{palette.grey60}",
+      "type": "color",
+      "description": "grey60"
+    },
     "barTrack": {
       "value": "{palette.grey30}",
       "type": "color",
@@ -2059,6 +2064,11 @@
       "value": "{palette.o2Red45}",
       "type": "color",
       "description": "o2Red45"
+    },
+    "chevronIndicator": {
+      "value": "{palette.grey60}",
+      "type": "color",
+      "description": "grey60"
     },
     "barTrack": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -655,6 +655,11 @@
       "type": "color",
       "description": "pepper"
     },
+    "chevronIndicator": {
+      "value": "{palette.grey5}",
+      "type": "color",
+      "description": "grey5"
+    },
     "barTrack": {
       "value": "{palette.grey3}",
       "type": "color",
@@ -2027,6 +2032,11 @@
       "value": "{palette.pepper}",
       "type": "color",
       "description": "pepper"
+    },
+    "chevronIndicator": {
+      "value": "{palette.grey5}",
+      "type": "color",
+      "description": "grey5"
     },
     "barTrack": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/schema/skin-schema.json
+++ b/tokens/schema/skin-schema.json
@@ -599,7 +599,7 @@
         "tagBackgroundInfoNegative": { "$ref": "#/definitions/constantProperties" },
         "tagBackgroundSuccessNegative": { "$ref": "#/definitions/constantProperties" },
         "tagBackgroundWarningNegative": { "$ref": "#/definitions/constantProperties" },
-        "tagBackgroundErrorNegative": { "$ref": "#/definitions/constantProperties" },
+        "chevronIndicator": { "$ref": "#/definitions/constantProperties" },
         "extended": {
           "type": "object",
           "patternProperties": {

--- a/tokens/schema/skin-schema.json
+++ b/tokens/schema/skin-schema.json
@@ -599,6 +599,7 @@
         "tagBackgroundInfoNegative": { "$ref": "#/definitions/constantProperties" },
         "tagBackgroundSuccessNegative": { "$ref": "#/definitions/constantProperties" },
         "tagBackgroundWarningNegative": { "$ref": "#/definitions/constantProperties" },
+        "tagBackgroundErrorNegative": { "$ref": "#/definitions/constantProperties" },
         "chevronIndicator": { "$ref": "#/definitions/constantProperties" },
         "extended": {
           "type": "object",

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -655,6 +655,11 @@
       "type": "color",
       "description": "coral60"
     },
+    "chevronIndicator": {
+      "value": "{palette.grey5}",
+      "type": "color",
+      "description": "grey5"
+    },
     "barTrack": {
       "value": "{palette.grey2}",
       "type": "color",
@@ -2027,6 +2032,11 @@
       "value": "{palette.coral}",
       "type": "color",
       "description": "coral"
+    },
+    "chevronIndicator": {
+      "value": "{palette.grey5}",
+      "type": "color",
+      "description": "grey5"
     },
     "barTrack": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/tu.json
+++ b/tokens/tu.json
@@ -655,6 +655,11 @@
       "type": "color",
       "description": "red"
     },
+    "chevronIndicator": {
+      "value": "{palette.grey5}",
+      "type": "color",
+      "description": "grey5"
+    },
     "barTrack": {
       "value": "{palette.grey2}",
       "type": "color",
@@ -2027,6 +2032,11 @@
       "value": "{palette.red}",
       "type": "color",
       "description": "red"
+    },
+    "chevronIndicator": {
+      "value": "{palette.grey5}",
+      "type": "color",
+      "description": "grey5"
     },
     "barTrack": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -655,6 +655,11 @@
       "type": "color",
       "description": "pepper"
     },
+    "chevronIndicator": {
+      "value": "{palette.grey5}",
+      "type": "color",
+      "description": "grey5"
+    },
     "barTrack": {
       "value": "{palette.grey3}",
       "type": "color",
@@ -2027,6 +2032,11 @@
       "value": "{palette.pepper}",
       "type": "color",
       "description": "pepper"
+    },
+    "chevronIndicator": {
+      "value": "{palette.grey5}",
+      "type": "color",
+      "description": "grey5"
     },
     "barTrack": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -655,6 +655,11 @@
       "type": "color",
       "description": "pepper"
     },
+    "chevronIndicator": {
+      "value": "{palette.grey5}",
+      "type": "color",
+      "description": "grey5"
+    },
     "barTrack": {
       "value": "{palette.grey3}",
       "type": "color",
@@ -2027,6 +2032,11 @@
       "value": "{palette.pepper}",
       "type": "color",
       "description": "pepper"
+    },
+    "chevronIndicator": {
+      "value": "{palette.grey5}",
+      "type": "color",
+      "description": "grey5"
     },
     "barTrack": {
       "value": "{palette.darkModeGrey6}",


### PR DESCRIPTION
The new chevronIndicator token maps to movistarBlue in the Movistar brand, while it remains neutral for the rest of the brands. In eSimFlag, the chevron in dark mode has been adjusted to grey4 to improve visibility.