### PR TITLE
divider updated to grey200

### DIFF
--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -736,9 +736,9 @@
       "description": "movistarBlue"
     },
     "divider": {
-      "value": "{palette.grey300}",
+      "value": "{palette.grey200}",
       "type": "color",
-      "description": "grey300"
+      "description": "grey200"
     },
     "dividerInverse": {
       "value": "rgba({palette.white}, 0.2)",


### PR DESCRIPTION
### Pull Request Description: Update Divider Color to Grey200

This pull request updates the `divider` color in the `movistar-new.json` file from `grey300` to `grey200`. 

#### Motivation
The change to `grey200` enhances the visual consistency of our design system. By using a lighter shade for the divider, we aim to create a more subtle separation between UI elements, improving overall readability and aesthetics.

#### Improvements
- **Visual Consistency**: The lighter divider better aligns with the current design trends, ensuring our UI remains modern and user-friendly.
- **Enhanced Readability**: A more subtle divider reduces visual clutter, allowing users to focus on content without distractions.

This update contributes to the overall quality and cohesiveness of the project's design, ensuring a better user experience.