### PR TITLE
new token chipLabel

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -2884,6 +2884,10 @@
       "text10": {
         "value": "light",
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": "medium",
+        "type": "typography"
       }
     },
     "size": {
@@ -2970,6 +2974,13 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3054,6 +3065,13 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 20,
+          "desktop": 22
         },
         "type": "typography"
       }

--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -3071,7 +3071,7 @@
       "chipLabel": {
         "value": {
           "mobile": 20,
-          "desktop": 22
+          "desktop":24 
         },
         "type": "typography"
       }

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -3093,7 +3093,7 @@
       "chipLabel": {
         "value": {
           "mobile": 20,
-          "desktop": 22
+          "desktop": 24
         },
         "type": "typography"
       }

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -2906,6 +2906,10 @@
       "text10": {
         "value": "bold",
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": "medium",
+        "type": "typography"
       }
     },
     "size": {
@@ -2992,6 +2996,13 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3076,6 +3087,13 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 20,
+          "desktop": 22
         },
         "type": "typography"
       }

--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -2874,6 +2874,10 @@
       "text10": {
         "value": "bold",
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": "medium",
+        "type": "typography"
       }
     },
     "size": {
@@ -2960,6 +2964,13 @@
           "desktop": 56
         },
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 14,
+          "desktop": 18
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3044,6 +3055,13 @@
         "value": {
           "mobile": 56,
           "desktop": 64
+        },
+        "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
         },
         "type": "typography"
       }

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -3061,7 +3061,7 @@
       "chipLabel": {
         "value": {
           "mobile": 20,
-          "desktop": 22
+          "desktop": 24
         },
         "type": "typography"
       }

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -2874,6 +2874,10 @@
       "text10": {
         "value": "bold",
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": "medium",
+        "type": "typography"
       }
     },
     "size": {
@@ -2960,6 +2964,13 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3044,6 +3055,13 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 20,
+          "desktop": 22
         },
         "type": "typography"
       }

--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -3093,7 +3093,7 @@
       "chipLabel": {
         "value": {
           "mobile": 20,
-          "desktop": 22
+          "desktop": 24
         },
         "type": "typography"
       }

--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -2906,6 +2906,10 @@
       "text10": {
         "value": "bold",
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": "medium",
+        "type": "typography"
       }
     },
     "size": {
@@ -2992,6 +2996,13 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3076,6 +3087,13 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 20,
+          "desktop": 22
         },
         "type": "typography"
       }

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -3061,7 +3061,7 @@
       "chipLabel": {
         "value": {
           "mobile": 20,
-          "desktop": 22
+          "desktop": 24
         },
         "type": "typography"
       }

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -2874,6 +2874,10 @@
       "text10": {
         "value": "light",
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": "medium",
+        "type": "typography"
       }
     },
     "size": {
@@ -2960,6 +2964,13 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3044,6 +3055,13 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 20,
+          "desktop": 22
         },
         "type": "typography"
       }

--- a/tokens/schema/skin-schema.json
+++ b/tokens/schema/skin-schema.json
@@ -655,7 +655,8 @@
         "text7": { "$ref": "#/definitions/weightProperties" },
         "text8": { "$ref": "#/definitions/weightProperties" },
         "text9": { "$ref": "#/definitions/weightProperties" },
-        "text10": { "$ref": "#/definitions/weightProperties" }
+        "text10": { "$ref": "#/definitions/weightProperties" },
+        "chipLabel": { "$ref": "#/definitions/weightProperties" }
       }
     },
     "size": {
@@ -672,7 +673,8 @@
         "text7": { "$ref": "#/definitions/sizeProperties" },
         "text8": { "$ref": "#/definitions/sizeProperties" },
         "text9": { "$ref": "#/definitions/sizeProperties" },
-        "text10": { "$ref": "#/definitions/sizeProperties" }
+        "text10": { "$ref": "#/definitions/sizeProperties" },
+        "chipLabel": { "$ref": "#/definitions/sizeProperties" }
       }
     },
     "lineHeight": {
@@ -689,7 +691,8 @@
         "text7": { "$ref": "#/definitions/lineHeightProperties" },
         "text8": { "$ref": "#/definitions/lineHeightProperties" },
         "text9": { "$ref": "#/definitions/lineHeightProperties" },
-        "text10": { "$ref": "#/definitions/lineHeightProperties" }
+        "text10": { "$ref": "#/definitions/lineHeightProperties" },
+        "chipLabel": { "$ref": "#/definitions/lineHeightProperties" }
       }
     },
     "themeVariant": {

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -3061,7 +3061,7 @@
       "chipLabel": {
         "value": {
           "mobile": 20,
-          "desktop": 22
+          "desktop": 24
         },
         "type": "typography"
       }

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -2874,6 +2874,10 @@
       "text10": {
         "value": "regular",
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": "medium",
+        "type": "typography"
       }
     },
     "size": {
@@ -2960,6 +2964,13 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3044,6 +3055,13 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 20,
+          "desktop": 22
         },
         "type": "typography"
       }

--- a/tokens/tu.json
+++ b/tokens/tu.json
@@ -2874,6 +2874,10 @@
       "text10": {
         "value": "medium",
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": "medium",
+        "type": "typography"
       }
     },
     "size": {
@@ -2960,6 +2964,13 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3044,6 +3055,13 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 20,
+          "desktop": 22
         },
         "type": "typography"
       }

--- a/tokens/tu.json
+++ b/tokens/tu.json
@@ -3061,7 +3061,7 @@
       "chipLabel": {
         "value": {
           "mobile": 20,
-          "desktop": 22
+          "desktop": 24
         },
         "type": "typography"
       }

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -3061,7 +3061,7 @@
       "chipLabel": {
         "value": {
           "mobile": 20,
-          "desktop": 22
+          "desktop": 24
         },
         "type": "typography"
       }

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -2874,6 +2874,10 @@
       "text10": {
         "value": "regular",
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": "medium",
+        "type": "typography"
       }
     },
     "size": {
@@ -2960,6 +2964,13 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3044,6 +3055,13 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 20,
+          "desktop": 22
         },
         "type": "typography"
       }

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -3061,7 +3061,7 @@
       "chipLabel": {
         "value": {
           "mobile": 20,
-          "desktop": 22
+          "desktop": 24
         },
         "type": "typography"
       }

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -2874,6 +2874,10 @@
       "text10": {
         "value": "light",
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": "medium",
+        "type": "typography"
       }
     },
     "size": {
@@ -2960,6 +2964,13 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3044,6 +3055,13 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "chipLabel": {
+        "value": {
+          "mobile": 20,
+          "desktop": 22
         },
         "type": "typography"
       }


### PR DESCRIPTION
### Pull Request Description: New Token `chipLabel`

This pull request introduces a new typography token, `chipLabel`, across various token files including `blau.json`, `esimflag.json`, `movistar-new.json`, `movistar.json`, `o2-new.json`, `o2.json`, `telefonica.json`, `tu.json`, `vivo-new.json`, and `vivo.json`. 

#### Motivation for the Change:
The addition of the `chipLabel` token is aimed at enhancing the design consistency and flexibility of our UI components that utilize chip labels. This token allows for unified styling across different screen sizes, ensuring that our design system remains coherent and adaptable to various use cases. 

#### Improvements to the Project:
- **Consistency**: By defining a standard `chipLabel` token, we ensure that all chip labels across the application adhere to the same typography rules, improving visual consistency.
- **Responsiveness**: The `chipLabel` token includes mobile and desktop values, promoting responsive design practices and enhancing user experience on different devices.
- **Maintainability**: Centralizing typography tokens reduces redundancy and makes it easier to manage and update styles in the future.

This change is crucial for maintaining a robust and scalable design system, ultimately leading to a better user experience.