### PR TITLE
Add input text tokens

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -2970,6 +2970,27 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3054,6 +3075,27 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
         },
         "type": "typography"
       }

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -2992,6 +2992,27 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3076,6 +3097,27 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
         },
         "type": "typography"
       }

--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -2960,6 +2960,27 @@
           "desktop": 56
         },
         "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 16,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 14,
+          "desktop": 14
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3044,6 +3065,27 @@
         "value": {
           "mobile": 56,
           "desktop": 64
+        },
+        "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 22,
+          "desktop": 22
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 20,
+          "desktop": 20
         },
         "type": "typography"
       }

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -2960,6 +2960,27 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3044,6 +3065,27 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
         },
         "type": "typography"
       }

--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -2992,6 +2992,27 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3076,6 +3097,27 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
         },
         "type": "typography"
       }

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -2960,6 +2960,27 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3044,6 +3065,27 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
         },
         "type": "typography"
       }

--- a/tokens/schema/skin-schema.json
+++ b/tokens/schema/skin-schema.json
@@ -672,7 +672,10 @@
         "text7": { "$ref": "#/definitions/sizeProperties" },
         "text8": { "$ref": "#/definitions/sizeProperties" },
         "text9": { "$ref": "#/definitions/sizeProperties" },
-        "text10": { "$ref": "#/definitions/sizeProperties" }
+        "text10": { "$ref": "#/definitions/sizeProperties" },
+        "inputLabel": { "$ref": "#/definitions/sizeProperties" },
+        "inputValue": { "$ref": "#/definitions/sizeProperties" },
+        "inputHelperText": { "$ref": "#/definitions/sizeProperties" }
       }
     },
     "lineHeight": {
@@ -689,7 +692,10 @@
         "text7": { "$ref": "#/definitions/lineHeightProperties" },
         "text8": { "$ref": "#/definitions/lineHeightProperties" },
         "text9": { "$ref": "#/definitions/lineHeightProperties" },
-        "text10": { "$ref": "#/definitions/lineHeightProperties" }
+        "text10": { "$ref": "#/definitions/lineHeightProperties" },
+        "inputLabel": { "$ref": "#/definitions/lineHeightProperties" },
+        "inputValue": { "$ref": "#/definitions/lineHeightProperties" },
+        "inputHelperText": { "$ref": "#/definitions/lineHeightProperties" }
       }
     },
     "themeVariant": {

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -2960,6 +2960,27 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3044,6 +3065,27 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
         },
         "type": "typography"
       }

--- a/tokens/tu.json
+++ b/tokens/tu.json
@@ -2960,6 +2960,27 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3044,6 +3065,27 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
         },
         "type": "typography"
       }

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -2960,6 +2960,27 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3044,6 +3065,27 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
         },
         "type": "typography"
       }

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -2960,6 +2960,27 @@
           "desktop": 64
         },
         "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3044,6 +3065,27 @@
         "value": {
           "mobile": 56,
           "desktop": 72
+        },
+        "type": "typography"
+      },
+      "inputLabel": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "inputValue": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "inputHelperText": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
         },
         "type": "typography"
       }


### PR DESCRIPTION
### Pull Request Description: Add Input Text Tokens

This pull request introduces new typography tokens specifically for input fields, enhancing our design system's consistency and usability. The following tokens have been added across multiple JSON files:

- **inputLabel**: Defines the font size for input labels, accommodating both mobile and desktop views.
- **inputValue**: Specifies the font size for the text entered in input fields, ensuring readability and accessibility.
- **inputHelperText**: Sets the font size for helper text associated with input fields, providing users with clear guidance.

### Motivation

The motivation behind this change is to standardize the typography used in input elements across our application. By adding these tokens, we ensure that all input-related text maintains uniformity in design, improving the overall user experience. This enhancement allows for better scalability and adaptability of our UI components, making it easier to maintain and style input fields consistently.

### Improvements to the Project

1. **Consistency**: Establishing a standard for input text helps maintain a cohesive design language throughout the application.
2. **Accessibility**: Clear typography for input labels, values, and helper text enhances readability, making the application more user-friendly.
3. **Ease of Maintenance**: With dedicated tokens for input fields, future updates and adjustments to typography can be made efficiently across the project.

This change is an important step forward in refining our design tokens and ensuring our application remains user-centric and visually appealing.