### PR TITLE
Update Dark Variant to Use textActivated Color for Selected TabBar Items

### DIFF
--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -1939,9 +1939,9 @@
       "description": "vivoPurpleLight50"
     },
     "textActivated": {
-      "value": "{palette.vivoPurpleLight80}",
+      "value": "{palette.vivoPurpleLight20}",
       "type": "color",
-      "description": "vivoPurpleLight80"
+      "description": "vivoPurpleLight20"
     },
     "textBrand": {
       "value": "{palette.vivoPurpleLight80}",


### PR DESCRIPTION
TabBar text and icons in the selected state use the textActivated color, when rendered in Liquid Glass with a dark background we need to redefine the current dark variant.

This is not a breaking change: the dark variant is not used in Vivo so updating its values will not affect current behavior outside the Liquid Glass context.

<img width="909" height="552" alt="image" src="https://github.com/user-attachments/assets/e85874cc-b8fd-43a2-98de-ad8e2d720415" />
