### PR TITLE
Add new loadingScreenTitle token

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -3034,6 +3034,13 @@
           "desktop": 16
         },
         "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 18,
+          "desktop": 20
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3174,6 +3181,13 @@
         "value": {
           "mobile": 20,
           "desktop": 24
+        },
+        "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 28
         },
         "type": "typography"
       }

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -3056,6 +3056,13 @@
           "desktop": 16
         },
         "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 18,
+          "desktop": 20
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3196,6 +3203,13 @@
         "value": {
           "mobile": 20,
           "desktop": 24
+        },
+        "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 28
         },
         "type": "typography"
       }

--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -3024,6 +3024,13 @@
           "desktop": 14
         },
         "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 28
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3164,6 +3171,13 @@
         "value": {
           "mobile": 16,
           "desktop": 20
+        },
+        "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 28,
+          "desktop": 32
         },
         "type": "typography"
       }

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -3024,6 +3024,13 @@
           "desktop": 16
         },
         "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 18,
+          "desktop": 20
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3164,6 +3171,13 @@
         "value": {
           "mobile": 20,
           "desktop": 24
+        },
+        "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 28
         },
         "type": "typography"
       }

--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -3056,6 +3056,13 @@
           "desktop": 16
         },
         "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 18,
+          "desktop": 20
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3196,6 +3203,13 @@
         "value": {
           "mobile": 20,
           "desktop": 24
+        },
+        "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 28
         },
         "type": "typography"
       }

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -3024,6 +3024,13 @@
           "desktop": 16
         },
         "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 18,
+          "desktop": 20
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3164,6 +3171,13 @@
         "value": {
           "mobile": 20,
           "desktop": 24
+        },
+        "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 28
         },
         "type": "typography"
       }

--- a/tokens/schema/skin-schema.json
+++ b/tokens/schema/skin-schema.json
@@ -682,7 +682,8 @@
         "inputLabel": { "$ref": "#/definitions/sizeProperties" },
         "inputValue": { "$ref": "#/definitions/sizeProperties" },
         "inputHelperText": { "$ref": "#/definitions/sizeProperties" },
-        "stepperStepLabel": { "$ref": "#/definitions/sizeProperties" }
+        "stepperStepLabel": { "$ref": "#/definitions/sizeProperties" },
+        "loadingScreenTitle": { "$ref": "#/definitions/sizeProperties" }
       }
     },
     "lineHeight": {
@@ -707,7 +708,8 @@
         "inputLabel": { "$ref": "#/definitions/lineHeightProperties" },
         "inputValue": { "$ref": "#/definitions/lineHeightProperties" },
         "inputHelperText": { "$ref": "#/definitions/lineHeightProperties" },
-        "stepperStepLabel": { "$ref": "#/definitions/lineHeightProperties" }
+        "stepperStepLabel": { "$ref": "#/definitions/lineHeightProperties" },
+        "loadingScreenTitle": { "$ref": "#/definitions/lineHeightProperties" }
       }
     },
     "themeVariant": {

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -3024,6 +3024,13 @@
           "desktop": 16
         },
         "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 18,
+          "desktop": 20
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3164,6 +3171,13 @@
         "value": {
           "mobile": 20,
           "desktop": 24
+        },
+        "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 28
         },
         "type": "typography"
       }

--- a/tokens/tu.json
+++ b/tokens/tu.json
@@ -3024,6 +3024,13 @@
           "desktop": 16
         },
         "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 18,
+          "desktop": 20
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3164,6 +3171,13 @@
         "value": {
           "mobile": 20,
           "desktop": 24
+        },
+        "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 28
         },
         "type": "typography"
       }

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -3024,6 +3024,13 @@
           "desktop": 16
         },
         "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 18,
+          "desktop": 24
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3164,6 +3171,13 @@
         "value": {
           "mobile": 20,
           "desktop": 24
+        },
+        "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 28
         },
         "type": "typography"
       }

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -3024,6 +3024,13 @@
           "desktop": 16
         },
         "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 18,
+          "desktop": 20
+        },
+        "type": "typography"
       }
     },
     "lineHeight": {
@@ -3164,6 +3171,13 @@
         "value": {
           "mobile": 20,
           "desktop": 24
+        },
+        "type": "typography"
+      },
+      "loadingScreenTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 28
         },
         "type": "typography"
       }


### PR DESCRIPTION
### Pull Request Description: Add New loadingScreenTitle Token

This pull request introduces a new `loadingScreenTitle` token across multiple design token files. The motivation behind this addition is to enhance our user interface by providing a standardized way to define typography for loading screen titles.

#### Key Changes:
- Added `loadingScreenTitle` token with responsive values for mobile and desktop across various token files, including `blau.json`, `esimflag.json`, `movistar-new.json`, `movistar.json`, `o2-new.json`, `o2.json`, `telefonica.json`, `tu.json`, `vivo-new.json`, and `vivo.json`.
- Each implementation includes specific font sizes for both mobile and desktop views, ensuring consistency in design.

#### Benefits:
- **Consistency**: This token allows for a uniform appearance of loading screen titles across different platforms and devices.
- **Maintainability**: Centralizing typography settings in tokens makes it easier to manage and update styles as needed.
- **Improved User Experience**: A well-defined loading screen title enhances user engagement during loading times, contributing to an overall better experience.

By integrating this token, we are taking a step toward a more cohesive and user-friendly interface, ensuring that our design system remains robust and adaptable.