### PR TITLE
Update backgroundSkeletonNegative values

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -96,9 +96,9 @@
       "description": "blauBlueSecondary"
     },
     "backgroundSkeletonNegative": {
-      "value": "{palette.blauBlueSecondary}",
+      "value": "rgba({palette.grey6}, 0.2)",
       "type": "color",
-      "description": "blauBlueSecondary"
+      "description": "grey6"
     },
     "backgroundSkeletonBrand": {
       "value": "{palette.blauBlueSecondary}",

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -128,9 +128,9 @@
       "description": "blue55"
     },
     "backgroundSkeletonNegative": {
-      "value": "{palette.blue55}",
+      "value": "rgba({palette.black}, 0.2)",
       "type": "color",
-      "description": "blue55"
+      "description": "black"
     },
     "backgroundSkeletonBrand": {
       "value": "{palette.blue55}",

--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -96,9 +96,9 @@
       "description": "blue800"
     },
     "backgroundSkeletonNegative": {
-      "value": "{palette.blue800}",
+      "value": "rgba({palette.darkModeBlack}, 0.4)",
       "type": "color",
-      "description": "blue800"
+      "description": "darkModeBlack"
     },
     "backgroundSkeletonBrand": {
       "value": "{palette.blue800}",

--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -96,9 +96,9 @@
       "description": "blue800"
     },
     "backgroundSkeletonNegative": {
-      "value": "rgba({palette.darkModeBlack}, 0.4)",
+      "value": "rgba({palette.black}, 0.2)",
       "type": "color",
-      "description": "darkModeBlack"
+      "description": "black"
     },
     "backgroundSkeletonBrand": {
       "value": "{palette.blue800}",

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -96,9 +96,9 @@
       "description": "movistarBlue55"
     },
     "backgroundSkeletonNegative": {
-      "value": "rgba({palette.movistarBlueDark}, 0.2)",
+      "value": "rgba({palette.black}, 0.2)",
       "type": "color",
-      "description": "movistarBlueDark"
+      "description": "black"
     },
     "backgroundSkeletonBrand": {
       "value": "{palette.movistarBlue55}",
@@ -1489,9 +1489,9 @@
       "description": "darkModeGrey6"
     },
     "backgroundSkeletonNegative": {
-      "value": "rgba({palette.black}, 0.2)",
+      "value": "{palette.darkModeGrey6}",
       "type": "color",
-      "description": "black"
+      "description": "darkModeGrey6"
     },
     "backgroundSkeletonBrand": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -96,9 +96,9 @@
       "description": "movistarBlue55"
     },
     "backgroundSkeletonNegative": {
-      "value": "{palette.movistarBlue55}",
+      "value": "rgba({palette.movistarBlueDark}, 0.2)",
       "type": "color",
-      "description": "movistarBlue55"
+      "description": "movistarBlueDark"
     },
     "backgroundSkeletonBrand": {
       "value": "{palette.movistarBlue55}",
@@ -1489,9 +1489,9 @@
       "description": "darkModeGrey6"
     },
     "backgroundSkeletonNegative": {
-      "value": "{palette.darkModeGrey6}",
+      "value": "rgba({palette.black}, 0.2)",
       "type": "color",
-      "description": "darkModeGrey6"
+      "description": "black"
     },
     "backgroundSkeletonBrand": {
       "value": "{palette.darkModeGrey6}",

--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -128,9 +128,9 @@
       "description": "beyondBlue70"
     },
     "backgroundSkeletonNegative": {
-      "value": "{palette.beyondBlue70}",
+      "value": "rgba({palette.black}, 0.2)",
       "type": "color",
-      "description": "beyondBlue70"
+      "description": "black"
     },
     "backgroundSkeletonBrand": {
       "value": "{palette.beyondBlue70}",
@@ -2235,7 +2235,7 @@
       "type": "color",
       "description": "grey30"
     },
-    "neutralHighNegative" : {
+    "neutralHighNegative": {
       "value": "{palette.grey30}",
       "type": "color",
       "description": "grey30"

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -96,9 +96,9 @@
       "description": "o2BluePrimary70"
     },
     "backgroundSkeletonNegative": {
-      "value": "{palette.o2BluePrimary70}",
+      "value": "rgba({palette.grey6}, 0.2)",
       "type": "color",
-      "description": "o2BluePrimary70"
+      "description": "grey6"
     },
     "backgroundSkeletonBrand": {
       "value": "{palette.o2BluePrimary70}",

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -96,9 +96,9 @@
       "description": "telefonicaBlue70"
     },
     "backgroundSkeletonNegative": {
-      "value": "{palette.telefonicaBlue70}",
+      "value": "rgba({palette.black}, 0.2)",
       "type": "color",
-      "description": "telefonicaBlue70"
+      "description": "black"
     },
     "backgroundSkeletonBrand": {
       "value": "{palette.telefonicaBlue70}",

--- a/tokens/tu.json
+++ b/tokens/tu.json
@@ -96,9 +96,9 @@
       "description": "primary65"
     },
     "backgroundSkeletonNegative": {
-      "value": "{palette.primary65}",
+      "value": "rgba({palette.black}, 0.2)",
       "type": "color",
-      "description": "primary65"
+      "description": "black"
     },
     "backgroundSkeletonBrand": {
       "value": "{palette.primary65}",

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -96,9 +96,9 @@
       "description": "vivoPurpleDark"
     },
     "backgroundSkeletonNegative": {
-      "value": "{palette.vivoPurpleDark}",
+      "value": "rgba({palette.grey6}, 0.2)",
       "type": "color",
-      "description": "vivoPurpleDark"
+      "description": "grey6"
     },
     "backgroundSkeletonBrand": {
       "value": "{palette.vivoPurpleDark}",

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -96,9 +96,9 @@
       "description": "vivoPurpleDark"
     },
     "backgroundSkeletonNegative": {
-      "value": "{palette.vivoPurpleDark}",
+      "value": "rgba({palette.grey6}, 0.2)",
       "type": "color",
-      "description": "vivoPurpleDark"
+      "description": "grey6"
     },
     "backgroundSkeletonBrand": {
       "value": "{palette.vivoPurpleDark}",


### PR DESCRIPTION
### Pull Request Description: Update backgroundSkeletonNegative Values

This pull request updates the `backgroundSkeletonNegative` values across multiple token files to enhance the visual consistency and accessibility of our UI components. 

#### Motivation
The previous color values for `backgroundSkeletonNegative` were based on specific palette colors that did not provide adequate contrast or clarity in certain contexts. By replacing these values with RGBA representations that utilize neutral colors (such as grey and black) with specific opacities, we aim to create a more universally applicable and visually appealing background.

#### Key Changes
- Updated `backgroundSkeletonNegative` values to use RGBA colors:
  - Replaced `{palette.blauBlueSecondary}` with `rgba({palette.grey6}, 0.2)`
  - Replaced `{palette.blue55}` with `rgba({palette.black}, 0.2)`
  - Replaced `{palette.blue800}` with `rgba({palette.darkModeBlack}, 0.4)`
  - Replaced `{palette.movistarBlue55}` with `rgba({palette.movistarBlueDark}, 0.2)`
  - And similar updates across other token files.

#### Benefits
- **Improved Accessibility**: The new color values provide better contrast and visibility, making it easier for users to distinguish UI elements.
- **Visual Consistency**: Using neutral colors ensures that the UI remains harmonious across different themes and palettes.
- **Maintainability**: The use of RGBA allows for easier adjustments of color opacity in the future, enhancing design flexibility.

This change is a step towards refining our design system and ensuring a better user experience.