### PR TITLE
new tokens for "rowList" and "boxedRowList"

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -2925,6 +2925,34 @@
       }
     },
     "size": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 16,
@@ -3074,6 +3102,34 @@
       }
     },
     "lineHeight": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 24,

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -2947,6 +2947,34 @@
       }
     },
     "size": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 16,
@@ -3096,6 +3124,34 @@
       }
     },
     "lineHeight": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 24,

--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -2915,6 +2915,34 @@
       }
     },
     "size": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 14,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 14,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 14,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 16,
@@ -3064,6 +3092,34 @@
       }
     },
     "lineHeight": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 20,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 20,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 20,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 24,

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -2915,6 +2915,34 @@
       }
     },
     "size": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 16,
@@ -3064,6 +3092,34 @@
       }
     },
     "lineHeight": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 24,

--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -2947,6 +2947,34 @@
       }
     },
     "size": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 16,
@@ -3096,6 +3124,34 @@
       }
     },
     "lineHeight": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 24,

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -2915,6 +2915,34 @@
       }
     },
     "size": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 16,
@@ -3064,6 +3092,34 @@
       }
     },
     "lineHeight": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 24,

--- a/tokens/schema/skin-schema.json
+++ b/tokens/schema/skin-schema.json
@@ -669,6 +669,10 @@
     "size": {
       "additionalProperties": false,
       "properties": {
+        "rowHeadline": { "$ref": "#/definitions/sizeProperties" },
+        "rowTitle": { "$ref": "#/definitions/sizeProperties" },
+        "rowSubtitle": { "$ref": "#/definitions/sizeProperties" },
+        "rowDescription": { "$ref": "#/definitions/sizeProperties" },
         "tabsLabel": { "$ref": "#/definitions/sizeProperties" },
         "title1": { "$ref": "#/definitions/sizeProperties" },
         "title2": { "$ref": "#/definitions/sizeProperties" },
@@ -695,6 +699,10 @@
     "lineHeight": {
       "additionalProperties": false,
       "properties": {
+        "rowHeadline": { "$ref": "#/definitions/lineHeightProperties" },
+        "rowTitle": { "$ref": "#/definitions/lineHeightProperties" },
+        "rowSubtitle": { "$ref": "#/definitions/lineHeightProperties" },
+        "rowDescription": { "$ref": "#/definitions/lineHeightProperties" },
         "tabsLabel": { "$ref": "#/definitions/lineHeightProperties" },
         "title1": { "$ref": "#/definitions/lineHeightProperties" },
         "title2": { "$ref": "#/definitions/lineHeightProperties" },

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -2915,6 +2915,34 @@
       }
     },
     "size": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 16,
@@ -3064,6 +3092,34 @@
       }
     },
     "lineHeight": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 24,

--- a/tokens/tu.json
+++ b/tokens/tu.json
@@ -2915,6 +2915,34 @@
       }
     },
     "size": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 16,
@@ -3064,6 +3092,34 @@
       }
     },
     "lineHeight": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 24,

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -2915,6 +2915,34 @@
       }
     },
     "size": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 18,
@@ -3064,6 +3092,34 @@
       }
     },
     "lineHeight": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 24,

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -2915,6 +2915,34 @@
       }
     },
     "size": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 12,
+          "desktop": 14
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 16,
+          "desktop": 18
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 14,
+          "desktop": 16
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 16,
@@ -3064,6 +3092,34 @@
       }
     },
     "lineHeight": {
+      "rowHeadline": {
+        "value": {
+          "mobile": 16,
+          "desktop": 20
+        },
+        "type": "typography"
+      },
+      "rowTitle": {
+        "value": {
+          "mobile": 24,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowSubtitle": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
+      "rowDescription": {
+        "value": {
+          "mobile": 20,
+          "desktop": 24
+        },
+        "type": "typography"
+      },
       "tabsLabel": {
         "value": {
           "mobile": 24,


### PR DESCRIPTION
As part of the Movistar alignment project, we also updated the RowList and BoxedRowList components to ensure consistent typography and better theme support across brands.

🆕 New tokens added

The following typography tokens have been introduced for both components:

`rowHeadline`
`rowTitle`
`rowSubtitle`
`rowDescription`

These tokens are aligned with Movistar’s updated typography specifications.
No existing tokens were altered; this PR exclusively adds the new tokens needed for these components.