### PR TITLE
chore(schema): force uppercase in color palettes

### DIFF
--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -3374,7 +3374,7 @@
         "type": "color"
       },
       "blue100": {
-        "value": "#f4f7f8",
+        "value": "#F4F7F8",
         "type": "color"
       },
       "blue200": {

--- a/tokens/schema/skin-schema.json
+++ b/tokens/schema/skin-schema.json
@@ -759,7 +759,7 @@
       "patternProperties": {
         "value": {
           "type": "string",
-          "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
+          "pattern": "^#([A-F0-9]{6}|[A-F0-9]{3})$"
         },
         "type": {
           "const": "color"

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -3402,19 +3402,19 @@
         "type": "color"
       },
       "yellow": {
-        "value": "#e4c35c",
+        "value": "#E4C35C",
         "type": "color"
       },
       "yellow15": {
-        "value": "#fcf7db",
+        "value": "#FCF7DB",
         "type": "color"
       },
       "yellow40": {
-        "value": "#f3e996",
+        "value": "#F3E996",
         "type": "color"
       },
       "yellow70": {
-        "value": "#a7863e",
+        "value": "#A7863E",
         "type": "color"
       },
       "yellow80": {
@@ -3422,15 +3422,15 @@
         "type": "color"
       },
       "coral": {
-        "value": "#d6786b",
+        "value": "#D6786B",
         "type": "color"
       },
       "coral10": {
-        "value": "#f9eeed",
+        "value": "#F9EEED",
         "type": "color"
       },
       "coral30": {
-        "value": "#f2b1a5",
+        "value": "#F2B1A5",
         "type": "color"
       },
       "coral60": {
@@ -3442,7 +3442,7 @@
         "type": "color"
       },
       "coral80": {
-        "value": "#843c34",
+        "value": "#843C34",
         "type": "color"
       },
       "coral90": {
@@ -3450,7 +3450,7 @@
         "type": "color"
       },
       "orchid": {
-        "value": "#b86be8",
+        "value": "#B86BE8",
         "type": "color"
       },
       "orchid10": {
@@ -3462,7 +3462,7 @@
         "type": "color"
       },
       "orchid70": {
-        "value": "#7f258e",
+        "value": "#7F258E",
         "type": "color"
       },
       "orchid80": {
@@ -3470,11 +3470,11 @@
         "type": "color"
       },
       "turquoise": {
-        "value": "#75c0c7",
+        "value": "#75C0C7",
         "type": "color"
       },
       "turquoise10": {
-        "value": "#ebffff",
+        "value": "#EBFFFF",
         "type": "color"
       },
       "turquoise40": {
@@ -3486,7 +3486,7 @@
         "type": "color"
       },
       "turquoise80": {
-        "value": "#253d3c",
+        "value": "#253D3C",
         "type": "color"
       },
       "grey1": {
@@ -3502,7 +3502,7 @@
         "type": "color"
       },
       "grey4": {
-        "value": "#8f97af",
+        "value": "#8F97AF",
         "type": "color"
       },
       "grey5": {


### PR DESCRIPTION
Enforces the use of uppercase letters for color values in our color palettes. The motivation behind this change is to establish a consistent and standardized format for color definitions across our project. 

By converting color hex codes to uppercase, we reduce the likelihood of discrepancies that may arise from varying case usage. This not only enhances readability but also simplifies the validation process when working with color values.

Additionally, the schema has been updated to reflect this requirement, ensuring that any future color entries adhere to the same uppercase format. This change will improve overall code quality and maintainability, making it easier for developers to work with color tokens in the project.