### PR TITLE
Fix input padding value in mobile

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -3404,11 +3404,11 @@
     "inputPadding": {
       "value": {
         "top": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         },
         "bottom": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         }
       },

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -3426,11 +3426,11 @@
     "inputPadding": {
       "value": {
         "top": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         },
         "bottom": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         }
       },

--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -3394,11 +3394,11 @@
     "inputPadding": {
       "value": {
         "top": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 2
         },
         "bottom": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 2
         }
       },

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -3394,11 +3394,11 @@
     "inputPadding": {
       "value": {
         "top": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         },
         "bottom": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         }
       },

--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -3426,11 +3426,11 @@
     "inputPadding": {
       "value": {
         "top": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         },
         "bottom": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         }
       },

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -3394,11 +3394,11 @@
     "inputPadding": {
       "value": {
         "top": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         },
         "bottom": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         }
       },

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -3394,11 +3394,11 @@
     "inputPadding": {
       "value": {
         "top": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         },
         "bottom": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         }
       },

--- a/tokens/tu.json
+++ b/tokens/tu.json
@@ -3394,11 +3394,11 @@
     "inputPadding": {
       "value": {
         "top": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         },
         "bottom": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         }
       },

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -3394,11 +3394,11 @@
     "inputPadding": {
       "value": {
         "top": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         },
         "bottom": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         }
       },

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -3394,11 +3394,11 @@
     "inputPadding": {
       "value": {
         "top": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         },
         "bottom": {
-          "mobile": 18,
+          "mobile": 8,
           "desktop": 8
         }
       },


### PR DESCRIPTION
Addresses the input padding values for mobile devices across multiple JSON token files. The previous padding value of 18 has been adjusted to 8, which improves the overall user experience on mobile devices.

**Motivation for the Change:**
The original padding value was causing excessive space around input fields, leading to a suboptimal user interface on mobile devices. By reducing the padding to 8, we ensure that the input elements are more appropriately sized and aligned, enhancing usability and aesthetics.

**Improvements to the Project:**
- **Enhanced User Experience:** The reduced padding will provide a more compact layout, making input fields easier to interact with on smaller screens.
- **Consistency Across Tokens:** This change ensures uniformity in the design system, as the same padding value is applied consistently across various tokens.
- **Responsive Design:** By optimizing the mobile input padding, we are taking a step towards a more responsive and user-friendly design that adapts better to different screen sizes.

This update is crucial for improving the accessibility and functionality of our application on mobile devices.