### PR TITLE
Update top mobile drawer padding

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -3477,7 +3477,7 @@
     "drawerPadding": {
       "value": {
         "top": {
-          "mobile": 40,
+          "mobile": 32,
           "desktop": 40
         },
         "bottom": {

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -3499,7 +3499,7 @@
     "drawerPadding": {
       "value": {
         "top": {
-          "mobile": 40,
+          "mobile": 32,
           "desktop": 40
         },
         "bottom": {

--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -3467,7 +3467,7 @@
     "drawerPadding": {
       "value": {
         "top": {
-          "mobile": 40,
+          "mobile": 32,
           "desktop": 32
         },
         "bottom": {

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -3467,7 +3467,7 @@
     "drawerPadding": {
       "value": {
         "top": {
-          "mobile": 40,
+          "mobile": 32,
           "desktop": 40
         },
         "bottom": {

--- a/tokens/o2-new.json
+++ b/tokens/o2-new.json
@@ -3499,7 +3499,7 @@
     "drawerPadding": {
       "value": {
         "top": {
-          "mobile": 40,
+          "mobile": 32,
           "desktop": 40
         },
         "bottom": {

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -3467,7 +3467,7 @@
     "drawerPadding": {
       "value": {
         "top": {
-          "mobile": 40,
+          "mobile": 32,
           "desktop": 40
         },
         "bottom": {

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -3467,7 +3467,7 @@
     "drawerPadding": {
       "value": {
         "top": {
-          "mobile": 40,
+          "mobile": 32,
           "desktop": 40
         },
         "bottom": {

--- a/tokens/tu.json
+++ b/tokens/tu.json
@@ -3467,7 +3467,7 @@
     "drawerPadding": {
       "value": {
         "top": {
-          "mobile": 40,
+          "mobile": 32,
           "desktop": 40
         },
         "bottom": {

--- a/tokens/vivo-new.json
+++ b/tokens/vivo-new.json
@@ -3467,7 +3467,7 @@
     "drawerPadding": {
       "value": {
         "top": {
-          "mobile": 40,
+          "mobile": 32,
           "desktop": 40
         },
         "bottom": {

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -3467,7 +3467,7 @@
     "drawerPadding": {
       "value": {
         "top": {
-          "mobile": 40,
+          "mobile": 32,
           "desktop": 40
         },
         "bottom": {


### PR DESCRIPTION
Top mobile was defined as 40

Web prod is defined as 40:

<img width="344" height="841" alt="Screenshot 2026-02-02 at 15 54 34" src="https://github.com/user-attachments/assets/42c2f902-211d-42ce-a53c-df97b9b608b0" />


New spec updated to align title and dismiss has updated top mobile to be 32:

https://www.figma.com/design/NfM16IJ4ffPVEdiFbtU0Lu/%F0%9F%94%B8-Drawer-Specs?node-id=40-5191&t=Ax7fXhuay4XKAKUg-4

