### PR TITLE
Fix input padding value

### DIFF
--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -3395,11 +3395,11 @@
       "value": {
         "top": {
           "mobile": 8,
-          "desktop": 2
+          "desktop": 3
         },
         "bottom": {
           "mobile": 8,
-          "desktop": 2
+          "desktop": 3
         }
       },
       "type": "spacing"


### PR DESCRIPTION
## Movistar new

In order to achieve 48px height input the calc should be like:

`inputTotalHeight = lineheight(inputValue) + lineheight(inputLabel) + 2x inputPadding`

in desktop the calc is like:

`inputTotalHeight = 22 + 20 + 3 + 3`

resulting in 48

## Other brands

The input height is defined as 60

in desktop the calc is like:

`inputTotalHeight = 24 + 20 + 8 + 8`

resulting in 60
