### PR TITLE
feat(Movistar): change some palette colors

### DIFF
--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -3573,7 +3573,7 @@
         "type": "color"
       },
       "salmonLight": {
-        "value": "#FFC6A8",
+        "value": "#FFDAC7",
         "type": "color"
       },
       "salmonDark": {
@@ -3601,7 +3601,7 @@
         "type": "color"
       },
       "yellowLight": {
-        "value": "#FFE99C",
+        "value": "#FFF0C0",
         "type": "color"
       },
       "yellowHigh": {
@@ -3633,7 +3633,7 @@
         "type": "color"
       },
       "greenLight": {
-        "value": "#CEF7BF",
+        "value": "#E2F8D5",
         "type": "color"
       },
       "greenHigh": {


### PR DESCRIPTION
### Pull Request Description

This pull request introduces updates to the color palette for the Movistar theme by changing specific color values in the `tokens/movistar-new.json` file. 

#### Motivation
The current palette colors did not align with the desired aesthetic and branding goals of the project. By updating the colors, we aim to create a more visually appealing and cohesive user experience that better reflects the Movistar brand identity.

#### Changes Made
- Updated the `salmonLight` color from `#FFC6A8` to `#FFDAC7`
- Updated the `yellowLight` color from `#FFE99C` to `#FFF0C0`
- Updated the `greenLight` color from `#CEF7BF` to `#E2F8D5`

#### Improvement
These changes enhance the overall visual design of the application, ensuring that our color palette is both modern and aligned with branding standards. This will contribute to a more engaging user interface and improve user satisfaction.