### PR TITLE
Increase mobile input padding in movistar-new

### DIFF
--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -3434,11 +3434,11 @@
     "inputPadding": {
       "value": {
         "top": {
-          "mobile": 8,
+          "mobile": 9,
           "desktop": 3
         },
         "bottom": {
-          "mobile": 8,
+          "mobile": 9,
           "desktop": 3
         }
       },


### PR DESCRIPTION
Proposes an increase in the mobile input padding for the "movistar-new" design token. The changes specifically adjust the top and bottom padding from 8px to 9px on mobile devices.

**Motivation:**
The primary motivation behind this change is to enhance the user experience on mobile devices by providing slightly more spacing around input fields. This adjustment aims to improve touch targets, making it easier for users to interact with forms and input elements, thereby reducing the likelihood of input errors.

**Improvements:**
By increasing the padding, we create a more comfortable and visually appealing interface, which can lead to improved usability and user satisfaction. This small yet impactful change reflects our commitment to continuously refining the mobile experience for our users.