### PR TITLE
Revert input value line height token to avoid input height changes

### DIFF
--- a/tokens/movistar-new.json
+++ b/tokens/movistar-new.json
@@ -3355,8 +3355,8 @@
       },
       "inputValue": {
         "value": {
-          "mobile": 22,
-          "desktop": 22
+          "mobile": 24,
+          "desktop": 24
         },
         "type": "typography"
       },


### PR DESCRIPTION
> [!WARNING]
> This change is temporary in order to avoid input height changes in https://github.com/Telefonica/mistica-web/pull/1488, value should be 22 again when https://jira.tid.es/browse/WEB-2382 is in development