### PR TITLE
Fix update changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,12 +20,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    env:
-      RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Set release version
+        run: |
+          if [ "${{ github.event_name }}" = "milestone" ]; then
+            echo "RELEASE_VERSION=${{ github.event.milestone.title }}" >> $GITHUB_ENV
+          else
+            echo "RELEASE_VERSION=${{ github.event.inputs.releaseVersion }}" >> $GITHUB_ENV
+          fi
 
       - name: Validate release version format
         run: |
@@ -44,6 +50,7 @@ jobs:
           OUTPUT_FOLDER: changelog-versions
           USE_MILESTONE_TITLE: "true"
           FILENAME_PREFIX: ${{ env.RELEASE_VERSION }}
+          MILESTONE_TITLE: ${{ github.event.milestone.title }}
 
       # - run: sudo python3 .github/resources/changelog-index-generator.py changelog-versions
 


### PR DESCRIPTION
Addresses an issue with the changelog workflow by enhancing the way the release version is determined and set. Previously, the workflow relied solely on the input parameter for the release version, which did not accommodate cases where the changelog needed to be generated from a milestone title.

With this update, the workflow now checks if the event is a milestone and sets the `RELEASE_VERSION` environment variable accordingly. This ensures that the changelog can be accurately generated based on milestone titles when applicable, providing a more robust and flexible approach to versioning.

By improving the changelog generation process, this change enhances the project's documentation quality and ensures that release notes are correctly associated with the appropriate versioning context. This ultimately leads to better clarity for contributors and users regarding project changes and updates.