### PR TITLE
feat(tokens): fix buttonLink neutral pill and text over inverted cont…

### DIFF
--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -373,9 +373,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundBrandPressed": {
-      "value": "{palette.grey1}",
+      "value": "rgba({palette.white}, 0.15)",
       "type": "color",
-      "description": "grey1"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundNegative": {
       "value": "rgba({palette.white}, 0)",
@@ -383,9 +383,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundNegativePressed": {
-      "value": "{palette.grey1}",
+      "value": "rgba({palette.white}, 0.15)",
       "type": "color",
-      "description": "grey1"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundMedia": {
       "value": "rgba({palette.white}, 0)",
@@ -393,9 +393,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundMediaPressed": {
-      "value": "{palette.grey1}",
+      "value": "rgba({palette.white}, 0.15)",
       "type": "color",
-      "description": "grey1"
+      "description": "white"
     },
     "buttonPrimaryBackground": {
       "value": "{palette.blauBlueSecondary}",

--- a/tokens/blau.json
+++ b/tokens/blau.json
@@ -368,7 +368,7 @@
       "description": "grey1"
     },
     "buttonLinkNeutralBackgroundBrand": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -378,7 +378,7 @@
       "description": "grey1"
     },
     "buttonLinkNeutralBackgroundNegative": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -388,7 +388,7 @@
       "description": "grey1"
     },
     "buttonLinkNeutralBackgroundMedia": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -747,9 +747,9 @@
       "description": "grey6"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.grey6}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "grey6"
+      "description": "white"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.grey6}",
@@ -757,9 +757,9 @@
       "description": "grey6"
     },
     "textLinkNeutralMedia": {
-      "value": "{palette.grey6}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "grey6"
+      "description": "white"
     },
     "textActivated": {
       "value": "{palette.blauBlueSecondary}",

--- a/tokens/community/cyber.json
+++ b/tokens/community/cyber.json
@@ -314,7 +314,7 @@
       "description": "red10"
     },
     "buttonLinkBackgroundPressed": {
-      "value": "rgba({palette.brand}, 0.05)",
+      "value": "rgba({palette.brand}, 0.08)",
       "type": "color",
       "description": "brand"
     },
@@ -341,9 +341,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundPressed": {
-      "value": "{palette.grey10}",
+      "value": "rgba({palette.grey400}, 0.08)",
       "type": "color",
-      "description": "grey10"
+      "description": "grey400"
     },
     "buttonLinkNeutralBackgroundBrand": {
       "value": "rgba({palette.white}, 0)",
@@ -351,9 +351,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundBrandPressed": {
-      "value": "{palette.grey10}",
+      "value": "rgba({palette.white}, 0.12)",
       "type": "color",
-      "description": "grey10"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundNegative": {
       "value": "rgba({palette.white}, 0)",
@@ -361,9 +361,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundNegativePressed": {
-      "value": "{palette.grey10}",
+      "value": "rgba({palette.white}, 0.12)",
       "type": "color",
-      "description": "grey10"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundMedia": {
       "value": "rgba({palette.white}, 0)",
@@ -371,9 +371,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundMediaPressed": {
-      "value": "{palette.grey10}",
+      "value": "rgba({palette.white}, 0.12)",
       "type": "color",
-      "description": "grey10"
+      "description": "white"
     },
     "buttonPrimaryBackground": {
       "value": "{palette.black}",

--- a/tokens/community/cyber.json
+++ b/tokens/community/cyber.json
@@ -346,7 +346,7 @@
       "description": "grey10"
     },
     "buttonLinkNeutralBackgroundBrand": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -356,7 +356,7 @@
       "description": "grey10"
     },
     "buttonLinkNeutralBackgroundNegative": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -366,7 +366,7 @@
       "description": "grey10"
     },
     "buttonLinkNeutralBackgroundMedia": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -720,14 +720,14 @@
       "description": "grey900"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.grey900}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "grey900"
+      "description": "white"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.grey900}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "grey900"
+      "description": "white"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.grey900}",
@@ -735,9 +735,9 @@
       "description": "grey900"
     },
     "textLinkNeutralMedia": {
-      "value": "{palette.grey900}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "grey900"
+      "description": "white"
     },
     "textActivated": {
       "value": "{palette.brand70}",

--- a/tokens/community/cyber.json
+++ b/tokens/community/cyber.json
@@ -314,9 +314,9 @@
       "description": "red10"
     },
     "buttonLinkBackgroundPressed": {
-      "value": "{palette.brand10}",
+      "value": "rgba({palette.brand}, 0.05)",
       "type": "color",
-      "description": "brand10"
+      "description": "brand"
     },
     "buttonLinkBackgroundInversePressed": {
       "value": "rgba({palette.white}, 0.08)",

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -383,9 +383,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundBrandPressed": {
-      "value": "{palette.grey2}",
+      "value": "rgba({palette.white}, 0.08)",
       "type": "color",
-      "description": "grey2"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundNegative": {
       "value": "rgba({palette.white}, 0)",
@@ -393,9 +393,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundNegativePressed": {
-      "value": "{palette.grey2}",
+      "value": "rgba({palette.white}, 0.08)",
       "type": "color",
-      "description": "grey2"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundMedia": {
       "value": "rgba({palette.white}, 0)",
@@ -403,9 +403,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundMediaPressed": {
-      "value": "{palette.grey2}",
+      "value": "rgba({palette.white}, 0.08)",
       "type": "color",
-      "description": "grey2"
+      "description": "white"
     },
     "buttonPrimaryBackground": {
       "value": "{palette.blue}",

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -2387,14 +2387,14 @@
       "description": "grey3"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.purple30}",
+      "value": "{palette.grey3}",
       "type": "color",
-      "description": "purple30"
+      "description": "grey3"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.purple30}",
+      "value": "{palette.grey3}",
       "type": "color",
-      "description": "purple30"
+      "description": "grey3"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.grey3}",

--- a/tokens/esimflag.json
+++ b/tokens/esimflag.json
@@ -378,7 +378,7 @@
       "description": "grey3"
     },
     "buttonLinkNeutralBackgroundBrand": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -388,7 +388,7 @@
       "description": "grey2"
     },
     "buttonLinkNeutralBackgroundNegative": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -398,9 +398,9 @@
       "description": "grey2"
     },
     "buttonLinkNeutralBackgroundMedia": {
-      "value": "{palette.grey2}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
-      "description": "grey2"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundMediaPressed": {
       "value": "{palette.grey2}",
@@ -752,14 +752,14 @@
       "description": "blue85"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.blue85}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "blue85"
+      "description": "white"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.blue85}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "blue85"
+      "description": "white"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.blue85}",
@@ -767,9 +767,9 @@
       "description": "blue85"
     },
     "textLinkNeutralMedia": {
-      "value": "{palette.blue85}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "blue85"
+      "description": "white"
     },
     "textActivated": {
       "value": "{palette.blue}",
@@ -2387,14 +2387,14 @@
       "description": "grey3"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.grey3}",
+      "value": "{palette.purple30}",
       "type": "color",
-      "description": "grey3"
+      "description": "purple30"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.grey3}",
+      "value": "{palette.purple30}",
       "type": "color",
-      "description": "grey3"
+      "description": "purple30"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.grey3}",

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -351,9 +351,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundBrandPressed": {
-      "value": "{palette.grey100}",
+      "value": "rgba({palette.white}, 0.3)",
       "type": "color",
-      "description": "grey100"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundNegative": {
       "value": "rgba({palette.white}, 0)",
@@ -361,9 +361,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundNegativePressed": {
-      "value": "{palette.grey100}",
+      "value": "rgba({palette.white}, 0.3)",
       "type": "color",
-      "description": "grey100"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundMedia": {
       "value": "rgba({palette.white}, 0)",
@@ -371,9 +371,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundMediaPressed": {
-      "value": "{palette.grey100}",
+      "value": "rgba({palette.white}, 0.3)",
       "type": "color",
-      "description": "grey100"
+      "description": "white"
     },
     "buttonPrimaryBackground": {
       "value": "{palette.movistarBlue}",

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -2355,14 +2355,14 @@
       "description": "movistarWhite"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.darkModeMovistarBlue}",
+      "value": "{palette.movistarWhite}",
       "type": "color",
-      "description": "darkModeMovistarBlue"
+      "description": "movistarWhite"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.darkModeMovistarBlue}",
+      "value": "{palette.movistarWhite}",
       "type": "color",
-      "description": "darkModeMovistarBlue"
+      "description": "movistarWhite"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.movistarWhite}",

--- a/tokens/movistar.json
+++ b/tokens/movistar.json
@@ -346,7 +346,7 @@
       "description": "grey100"
     },
     "buttonLinkNeutralBackgroundBrand": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -356,7 +356,7 @@
       "description": "grey100"
     },
     "buttonLinkNeutralBackgroundNegative": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -366,7 +366,7 @@
       "description": "grey100"
     },
     "buttonLinkNeutralBackgroundMedia": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -720,14 +720,14 @@
       "description": "movistarBlack"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.movistarBlack}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "movistarBlack"
+      "description": "white"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.movistarBlack}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "movistarBlack"
+      "description": "white"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.movistarBlack}",
@@ -735,9 +735,9 @@
       "description": "movistarBlack"
     },
     "textLinkNeutralMedia": {
-      "value": "{palette.movistarBlack}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "movistarBlack"
+      "description": "white"
     },
     "textActivated": {
       "value": "{palette.blueHigh}",
@@ -2355,14 +2355,14 @@
       "description": "movistarWhite"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.movistarWhite}",
+      "value": "{palette.darkModeMovistarBlue}",
       "type": "color",
-      "description": "movistarWhite"
+      "description": "darkModeMovistarBlue"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.movistarWhite}",
+      "value": "{palette.darkModeMovistarBlue}",
       "type": "color",
-      "description": "movistarWhite"
+      "description": "darkModeMovistarBlue"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.movistarWhite}",

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -383,9 +383,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundBrandPressed": {
-      "value": "{palette.grey20}",
+      "value": "rgba({palette.white}, 0.08)",
       "type": "color",
-      "description": "grey20"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundNegative": {
       "value": "rgba({palette.white}, 0)",
@@ -393,9 +393,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundNegativePressed": {
-      "value": "{palette.grey20}",
+      "value": "rgba({palette.white}, 0.08)",
       "type": "color",
-      "description": "grey20"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundMedia": {
       "value": "rgba({palette.white}, 0)",
@@ -403,9 +403,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundMediaPressed": {
-      "value": "{palette.grey20}",
+      "value": "rgba({palette.white}, 0.08)",
       "type": "color",
-      "description": "grey20"
+      "description": "white"
     },
     "buttonPrimaryBackground": {
       "value": "{palette.beyondBlue}",

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -2387,14 +2387,14 @@
       "description": "grey30"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.beyondBlue40}",
+      "value": "{palette.grey30}",
       "type": "color",
-      "description": "beyondBlue40"
+      "description": "grey30"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.beyondBlue40}",
+      "value": "{palette.grey30}",
       "type": "color",
-      "description": "beyondBlue40"
+      "description": "grey30"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.grey30}",

--- a/tokens/o2.json
+++ b/tokens/o2.json
@@ -378,7 +378,7 @@
       "description": "grey30"
     },
     "buttonLinkNeutralBackgroundBrand": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -388,7 +388,7 @@
       "description": "grey20"
     },
     "buttonLinkNeutralBackgroundNegative": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -398,7 +398,7 @@
       "description": "grey20"
     },
     "buttonLinkNeutralBackgroundMedia": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -752,14 +752,14 @@
       "description": "black"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.black}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "black"
+      "description": "white"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.black}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "black"
+      "description": "white"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.black}",
@@ -767,9 +767,9 @@
       "description": "black"
     },
     "textLinkNeutralMedia": {
-      "value": "{palette.black}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "black"
+      "description": "white"
     },
     "textActivated": {
       "value": "{palette.beyondBlue}",
@@ -2387,14 +2387,14 @@
       "description": "grey30"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.grey30}",
+      "value": "{palette.beyondBlue40}",
       "type": "color",
-      "description": "grey30"
+      "description": "beyondBlue40"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.grey30}",
+      "value": "{palette.beyondBlue40}",
       "type": "color",
-      "description": "grey30"
+      "description": "beyondBlue40"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.grey30}",

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -351,9 +351,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundBrandPressed": {
-      "value": "{palette.grey1}",
+      "value": "rgba({palette.white}, 0.08)",
       "type": "color",
-      "description": "grey1"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundNegative": {
       "value": "rgba({palette.white}, 0)",
@@ -361,9 +361,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundNegativePressed": {
-      "value": "{palette.grey1}",
+      "value": "rgba({palette.white}, 0.08)",
       "type": "color",
-      "description": "grey1"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundMedia": {
       "value": "rgba({palette.white}, 0)",
@@ -371,9 +371,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundMediaPressed": {
-      "value": "{palette.grey1}",
+      "value": "rgba({palette.white}, 0.08)",
       "type": "color",
-      "description": "grey1"
+      "description": "white"
     },
     "buttonPrimaryBackground": {
       "value": "{palette.telefonicaBlue}",

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -2355,14 +2355,14 @@
       "description": "grey1"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.darkModeTelefonicaBlue}",
+      "value": "{palette.grey1}",
       "type": "color",
-      "description": "darkModeTelefonicaBlue"
+      "description": "grey1"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.darkModeTelefonicaBlue}",
+      "value": "{palette.grey1}",
       "type": "color",
-      "description": "darkModeTelefonicaBlue"
+      "description": "grey1"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.grey1}",

--- a/tokens/telefonica.json
+++ b/tokens/telefonica.json
@@ -346,7 +346,7 @@
       "description": "grey2"
     },
     "buttonLinkNeutralBackgroundBrand": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -356,7 +356,7 @@
       "description": "grey1"
     },
     "buttonLinkNeutralBackgroundNegative": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -366,7 +366,7 @@
       "description": "grey1"
     },
     "buttonLinkNeutralBackgroundMedia": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -720,14 +720,14 @@
       "description": "grey9"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.grey9}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "grey9"
+      "description": "white"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.grey9}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "grey9"
+      "description": "white"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.grey9}",
@@ -735,9 +735,9 @@
       "description": "grey9"
     },
     "textLinkNeutralMedia": {
-      "value": "{palette.grey9}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "grey9"
+      "description": "white"
     },
     "textActivated": {
       "value": "{palette.telefonicaBlue70}",
@@ -2355,14 +2355,14 @@
       "description": "grey1"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.grey1}",
+      "value": "{palette.darkModeTelefonicaBlue}",
       "type": "color",
-      "description": "grey1"
+      "description": "darkModeTelefonicaBlue"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.grey1}",
+      "value": "{palette.darkModeTelefonicaBlue}",
       "type": "color",
-      "description": "grey1"
+      "description": "darkModeTelefonicaBlue"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.grey1}",

--- a/tokens/unbranded.json
+++ b/tokens/unbranded.json
@@ -336,9 +336,9 @@
       "description": "black"
     },
     "buttonLinkNeutralBackgroundBrand": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.neutral100}, 0)",
       "type": "color",
-      "description": "white"
+      "description": "neutral100"
     },
     "buttonLinkNeutralBackgroundBrandPressed": {
       "value": "{palette.neutral50}",
@@ -346,9 +346,9 @@
       "description": "neutral50"
     },
     "buttonLinkNeutralBackgroundNegative": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.neutral100}, 0)",
       "type": "color",
-      "description": "white"
+      "description": "neutral100"
     },
     "buttonLinkNeutralBackgroundNegativePressed": {
       "value": "{palette.neutral50}",
@@ -356,9 +356,9 @@
       "description": "neutral50"
     },
     "buttonLinkNeutralBackgroundMedia": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.neutral100}, 0)",
       "type": "color",
-      "description": "white"
+      "description": "neutral100"
     },
     "buttonLinkNeutralBackgroundMediaPressed": {
       "value": "{palette.neutral50}",
@@ -686,14 +686,14 @@
       "description": "black"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.black}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "black"
+      "description": "white"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.black}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "black"
+      "description": "white"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.black}",
@@ -701,9 +701,9 @@
       "description": "black"
     },
     "textLinkNeutralMedia": {
-      "value": "{palette.black}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "black"
+      "description": "white"
     },
     "textActivated": {
       "value": "{palette.black}",

--- a/tokens/unbranded.json
+++ b/tokens/unbranded.json
@@ -341,9 +341,9 @@
       "description": "neutral100"
     },
     "buttonLinkNeutralBackgroundBrandPressed": {
-      "value": "{palette.neutral50}",
+      "value": "rgba({palette.white}, 0.1)",
       "type": "color",
-      "description": "neutral50"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundNegative": {
       "value": "rgba({palette.neutral100}, 0)",
@@ -351,9 +351,9 @@
       "description": "neutral100"
     },
     "buttonLinkNeutralBackgroundNegativePressed": {
-      "value": "{palette.neutral50}",
+      "value": "rgba({palette.white}, 0.1)",
       "type": "color",
-      "description": "neutral50"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundMedia": {
       "value": "rgba({palette.neutral100}, 0)",
@@ -361,9 +361,9 @@
       "description": "neutral100"
     },
     "buttonLinkNeutralBackgroundMediaPressed": {
-      "value": "{palette.neutral50}",
+      "value": "rgba({palette.white}, 0.1)",
       "type": "color",
-      "description": "neutral50"
+      "description": "white"
     },
     "buttonPrimaryBackground": {
       "value": "{palette.black}",

--- a/tokens/vivo-evolution.json
+++ b/tokens/vivo-evolution.json
@@ -346,9 +346,9 @@
       "description": "vivoNeutral100"
     },
     "buttonLinkNeutralBackgroundBrand": {
-      "value": "rgba({palette.white}, 0)",
+      "value": "rgba({palette.vivoNeutral0}, 0)",
       "type": "color",
-      "description": "white"
+      "description": "vivoNeutral0"
     },
     "buttonLinkNeutralBackgroundBrandPressed": {
       "value": "{palette.vivoNeutral25}",
@@ -356,9 +356,9 @@
       "description": "vivoNeutral25"
     },
     "buttonLinkNeutralBackgroundNegative": {
-      "value": "rgba({palette.white}, 0)",
+      "value": "rgba({palette.vivoNeutral0}, 0)",
       "type": "color",
-      "description": "white"
+      "description": "vivoNeutral0"
     },
     "buttonLinkNeutralBackgroundNegativePressed": {
       "value": "{palette.vivoNeutral25}",
@@ -366,9 +366,9 @@
       "description": "vivoNeutral25"
     },
     "buttonLinkNeutralBackgroundMedia": {
-      "value": "rgba({palette.white}, 0)",
+      "value": "rgba({palette.vivoNeutral0}, 0)",
       "type": "color",
-      "description": "white"
+      "description": "vivoNeutral0"
     },
     "buttonLinkNeutralBackgroundMediaPressed": {
       "value": "{palette.vivoNeutral25}",

--- a/tokens/vivo-evolution.json
+++ b/tokens/vivo-evolution.json
@@ -371,7 +371,7 @@
       "description": "vivoNeutral0"
     },
     "buttonLinkNeutralBackgroundMediaPressed": {
-       "value": "rgba({palette.vivoNeutral0}, 0.1)",
+      "value": "rgba({palette.vivoNeutral0}, 0.1)",
       "type": "color",
       "description": "vivoNeutral0"
     },

--- a/tokens/vivo-evolution.json
+++ b/tokens/vivo-evolution.json
@@ -351,9 +351,9 @@
       "description": "vivoNeutral0"
     },
     "buttonLinkNeutralBackgroundBrandPressed": {
-      "value": "{palette.vivoNeutral25}",
+      "value": "rgba({palette.vivoNeutral0}, 0.1)",
       "type": "color",
-      "description": "vivoNeutral25"
+      "description": "vivoNeutral0"
     },
     "buttonLinkNeutralBackgroundNegative": {
       "value": "rgba({palette.vivoNeutral0}, 0)",
@@ -361,9 +361,9 @@
       "description": "vivoNeutral0"
     },
     "buttonLinkNeutralBackgroundNegativePressed": {
-      "value": "{palette.vivoNeutral25}",
+      "value": "rgba({palette.vivoNeutral0}, 0.1)",
       "type": "color",
-      "description": "vivoNeutral25"
+      "description": "vivoNeutral0"
     },
     "buttonLinkNeutralBackgroundMedia": {
       "value": "rgba({palette.vivoNeutral0}, 0)",
@@ -371,9 +371,9 @@
       "description": "vivoNeutral0"
     },
     "buttonLinkNeutralBackgroundMediaPressed": {
-      "value": "{palette.vivoNeutral25}",
+       "value": "rgba({palette.vivoNeutral0}, 0.1)",
       "type": "color",
-      "description": "vivoNeutral25"
+      "description": "vivoNeutral0"
     },
     "buttonPrimaryBackground": {
       "value": "{palette.vivoPurple700}",

--- a/tokens/vivo-evolution.json
+++ b/tokens/vivo-evolution.json
@@ -346,9 +346,9 @@
       "description": "vivoNeutral100"
     },
     "buttonLinkNeutralBackgroundBrand": {
-      "value": "{palette.vivoNeutral0}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
-      "description": "vivoNeutral0"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundBrandPressed": {
       "value": "{palette.vivoNeutral25}",
@@ -356,9 +356,9 @@
       "description": "vivoNeutral25"
     },
     "buttonLinkNeutralBackgroundNegative": {
-      "value": "{palette.vivoNeutral0}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
-      "description": "vivoNeutral0"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundNegativePressed": {
       "value": "{palette.vivoNeutral25}",
@@ -366,9 +366,9 @@
       "description": "vivoNeutral25"
     },
     "buttonLinkNeutralBackgroundMedia": {
-      "value": "{palette.vivoNeutral0}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
-      "description": "vivoNeutral0"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundMediaPressed": {
       "value": "{palette.vivoNeutral25}",
@@ -720,14 +720,14 @@
       "description": "vivoNeutral975"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.vivoNeutral975}",
+      "value": "{palette.vivoNeutral0}",
       "type": "color",
-      "description": "vivoNeutral975"
+      "description": "vivoNeutral0"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.vivoNeutral975}",
+      "value": "{palette.vivoNeutral0}",
       "type": "color",
-      "description": "vivoNeutral975"
+      "description": "vivoNeutral0"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.vivoNeutral975}",
@@ -735,9 +735,9 @@
       "description": "vivoNeutral975"
     },
     "textLinkNeutralMedia": {
-      "value": "{palette.vivoNeutral975}",
+      "value": "{palette.vivoNeutral0}",
       "type": "color",
-      "description": "vivoNeutral975"
+      "description": "vivoNeutral0"
     },
     "textActivated": {
       "value": "{palette.vivoPurple700}",
@@ -2355,14 +2355,14 @@
       "description": "vivoNeutral100"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.vivoNeutral100}",
+      "value": "{palette.vivoPurple300}",
       "type": "color",
-      "description": "vivoNeutral100"
+      "description": "vivoPurple300"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.vivoNeutral100}",
+      "value": "{palette.vivoPurple300}",
       "type": "color",
-      "description": "vivoNeutral100"
+      "description": "vivoPurple300"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.vivoNeutral100}",

--- a/tokens/vivo-evolution.json
+++ b/tokens/vivo-evolution.json
@@ -2355,14 +2355,14 @@
       "description": "vivoNeutral100"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.vivoPurple300}",
+      "value": "{palette.vivoNeutral100}",
       "type": "color",
-      "description": "vivoPurple300"
+      "description": "vivoNeutral100"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.vivoPurple300}",
+      "value": "{palette.vivoNeutral100}",
       "type": "color",
-      "description": "vivoPurple300"
+      "description": "vivoNeutral100"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.vivoNeutral100}",

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -2355,14 +2355,14 @@
       "description": "grey2"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.vivoPurpleLight50}",
+      "value": "{palette.grey2}",
       "type": "color",
-      "description": "vivoPurpleLight50"
+      "description": "grey2"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.vivoPurpleLight50}",
+      "value": "{palette.grey2}",
       "type": "color",
-      "description": "vivoPurpleLight50"
+      "description": "grey2"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.grey2}",

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -351,9 +351,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundBrandPressed": {
-      "value": "{palette.grey1}",
+      "value": "rgba({palette.white}, 0.1)",
       "type": "color",
-      "description": "grey1"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundNegative": {
       "value": "rgba({palette.white}, 0)",
@@ -361,9 +361,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundNegativePressed": {
-      "value": "{palette.grey1}",
+      "value": "rgba({palette.white}, 0.1)",
       "type": "color",
-      "description": "grey1"
+      "description": "white"
     },
     "buttonLinkNeutralBackgroundMedia": {
       "value": "rgba({palette.white}, 0)",
@@ -371,9 +371,9 @@
       "description": "white"
     },
     "buttonLinkNeutralBackgroundMediaPressed": {
-      "value": "{palette.grey1}",
+      "value": "rgba({palette.white}, 0.1)",
       "type": "color",
-      "description": "grey1"
+      "description": "white"
     },
     "buttonPrimaryBackground": {
       "value": "{palette.vivoPurple}",

--- a/tokens/vivo.json
+++ b/tokens/vivo.json
@@ -346,7 +346,7 @@
       "description": "grey2"
     },
     "buttonLinkNeutralBackgroundBrand": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -356,7 +356,7 @@
       "description": "grey1"
     },
     "buttonLinkNeutralBackgroundNegative": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -366,7 +366,7 @@
       "description": "grey1"
     },
     "buttonLinkNeutralBackgroundMedia": {
-      "value": "{palette.white}",
+      "value": "rgba({palette.white}, 0)",
       "type": "color",
       "description": "white"
     },
@@ -720,14 +720,14 @@
       "description": "grey6"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.grey6}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "grey6"
+      "description": "white"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.grey6}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "grey6"
+      "description": "white"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.grey6}",
@@ -735,9 +735,9 @@
       "description": "grey6"
     },
     "textLinkNeutralMedia": {
-      "value": "{palette.grey6}",
+      "value": "{palette.white}",
       "type": "color",
-      "description": "grey6"
+      "description": "white"
     },
     "textActivated": {
       "value": "{palette.vivoPurple}",
@@ -2355,14 +2355,14 @@
       "description": "grey2"
     },
     "textLinkNeutralBrand": {
-      "value": "{palette.grey2}",
+      "value": "{palette.vivoPurpleLight50}",
       "type": "color",
-      "description": "grey2"
+      "description": "vivoPurpleLight50"
     },
     "textLinkNeutralNegative": {
-      "value": "{palette.grey2}",
+      "value": "{palette.vivoPurpleLight50}",
       "type": "color",
-      "description": "grey2"
+      "description": "vivoPurpleLight50"
     },
     "textLinkNeutralAlternative": {
       "value": "{palette.grey2}",


### PR DESCRIPTION
Remove the background pill from buttonLinkNeutral in brand, negative and media contexts by setting the resting background tokens to transparent in light mode across all skins. Dark mode was already transparent.

Align textLinkNeutralBrand, textLinkNeutralNegative and textLinkNeutralMedia with their non-neutral counterparts (textLinkBrand, textLinkNegative, textLinkMedia) **only in light** so text is readable directly on the inverted background without relying on the pill.

Blau text tokens are intentionally unchanged (by design) in Brand context. Cyber dark text tokens are intentionally unchanged — the fix for textLinkNeutral* missing from darkModeColors belongs in mistica-web.

Fixes #2722, #2803